### PR TITLE
httprequest: new package

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,185 @@
+This software is licensed under the LGPLv3, included below.
+
+As a special exception to the GNU Lesser General Public License version 3
+("LGPL3"), the copyright holders of this Library give you permission to
+convey to a third party a Combined Work that links statically or dynamically
+to this Library without providing any Minimal Corresponding Source or
+Minimal Application Code as set out in 4d or providing the installation
+information set out in section 4e, provided that you comply with the other
+provisions of LGPL3 and provided that you meet, for the Application the
+terms and conditions of the license(s) which apply to the Application.
+
+Except as stated in this special exception, the provisions of LGPL3 will
+continue to comply in full to this Library. If you modify this Library, you
+may apply this exception to your version of this Library, but you are not
+obliged to do so. If you do not wish to do so, delete this exception
+statement from your version. This exception does not (and cannot) modify any
+license terms which apply to the Application, with which you must still
+comply.
+
+
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# httprequest
+--
+    import "github.com/juju/httprequest"
+
+Package httprequest provides functionality for unmarshaling HTTP request
+parameters into a struct type.
+
+## Usage
+
+#### func  Unmarshal
+
+```go
+func Unmarshal(p Params, x interface{}) error
+```
+Unmarshal takes values from given parameters and fills out fields in x, which
+must be a pointer to a struct.
+
+Tags on the struct's fields determine where each field is filled in from.
+Similar to encoding/json and other encoding packages, the tag holds a
+comma-separated list. The first item in the list is an alternative name for the
+field (the field name itself will be used if this is empty). The next item
+specifies where the field is filled in from. It may be:
+
+    "path" - the field is taken from a parameter in p.PathVar
+    	with a matching field name.
+
+    "form" - the field is taken from the given name in p.Form
+    	(note that this covers both URL query parameters and
+    	POST form parameters)
+
+    "body" - the field is filled in by parsing the request body
+    	as JSON.
+
+For path and form parameters, the field will be filled out from the field in
+p.PathVar or p.Form using one of the following methods (in descending order of
+preference):
+
+- if the type is string, it will be set from the first value.
+
+- if the type is []string, it will be filled out using all values for that field
+
+    (allowed only for form)
+
+- if the type implements encoding.TextUnmarshaler, its UnmarshalText method will
+be used
+
+- otherwise fmt.Sscan will be used to set the value.
+
+#### type Params
+
+```go
+type Params struct {
+	*http.Request
+	PathVar httprouter.Params
+}
+```
+
+Params holds request parameters that can be unmarshaled into a struct.

--- a/package_test.go
+++ b/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package httprequest_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/type.go
+++ b/type.go
@@ -1,0 +1,468 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+// Package httprequest provides functionality for unmarshaling
+// HTTP request parameters into a struct type.
+package httprequest
+
+import (
+	"encoding"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/julienschmidt/httprouter"
+	"gopkg.in/errgo.v1"
+)
+
+// TODO include field name and source in error messages.
+
+var (
+	typeMutex sync.RWMutex
+	typeMap   = make(map[reflect.Type]*requestType)
+)
+
+// Params holds request parameters that can
+// be unmarshaled into a struct.
+type Params struct {
+	*http.Request
+	PathVar httprouter.Params
+}
+
+// resultMaker is provided to the unmarshal functions.
+// When called with the value passed to the unmarshaler,
+// it returns the field value to be assigned to,
+// creating it if necessary.
+type resultMaker func(reflect.Value) reflect.Value
+
+// unmarshaler unmarshals some value from params into
+// the given value. The value should not be assigned to directly,
+// but passed to makeResult and then updated.
+type unmarshaler func(v reflect.Value, p Params, makeResult resultMaker) error
+
+// requestType holds information derived from a request
+// type, preprocessed so that it's nice and quick to unmarshal.
+type requestType struct {
+	fields []field
+}
+
+// field holds preprocessed information on an individual field
+// in the result.
+type field struct {
+	// index holds the index slice of the field.
+	index []int
+
+	// unmarshal is used to unmarshal the value into
+	// the given field. The value passed as its first
+	// argument is not a pointer type, but is addressable.
+	unmarshal unmarshaler
+
+	// makeResult is the resultMaker that will be
+	// passed into the unmarshaler.
+	makeResult resultMaker
+}
+
+// Unmarshal takes values from given parameters and fills
+// out fields in x, which must be a pointer to a struct.
+//
+// Tags on the struct's fields determine where each field is filled in
+// from. Similar to encoding/json and other encoding packages, the tag
+// holds a comma-separated list. The first item in the list is an
+// alternative name for the field (the field name itself will be used if
+// this is empty). The next item specifies where the field is filled in
+// from. It may be:
+//
+//	"path" - the field is taken from a parameter in p.PathVar
+//		with a matching field name.
+//
+// 	"form" - the field is taken from the given name in p.Form
+//		(note that this covers both URL query parameters and
+//		POST form parameters)
+//
+//	"body" - the field is filled in by parsing the request body
+//		as JSON.
+//
+// For path and form parameters, the field will be filled out from
+// the field in p.PathVar or p.Form using one of the following
+// methods (in descending order of preference):
+//
+// - if the type is string, it will be set from the first value.
+//
+// - if the type is []string, it will be filled out using all values for that field
+//    (allowed only for form)
+//
+// - if the type implements encoding.TextUnmarshaler, its
+// UnmarshalText method will be used
+//
+// -  otherwise fmt.Sscan will be used to set the value.
+func Unmarshal(p Params, x interface{}) error {
+	xv := reflect.ValueOf(x)
+	pt, err := getRequestType(xv.Type())
+	if err != nil {
+		return errgo.Notef(err, "bad type %s", xv.Type())
+	}
+	xv = xv.Elem()
+	for _, f := range pt.fields {
+		fv := xv.FieldByIndex(f.index)
+		if err := f.unmarshal(fv, p, f.makeResult); err != nil {
+			return errgo.Mask(err)
+		}
+	}
+	return nil
+}
+
+// getRequestType is like parseRequestType except that
+// it returns the cached requestType when possible,
+// adding the type to the cache otherwise.
+func getRequestType(t reflect.Type) (*requestType, error) {
+	typeMutex.RLock()
+	pt := typeMap[t]
+	typeMutex.RUnlock()
+	if pt != nil {
+		return pt, nil
+	}
+	typeMutex.Lock()
+	defer typeMutex.Unlock()
+	if pt = typeMap[t]; pt != nil {
+		// The type has been parsed after we dropped
+		// the read lock, so use it.
+		return pt, nil
+	}
+	pt, err := parseRequestType(t)
+	if err != nil {
+		return nil, errgo.Mask(err)
+	}
+	typeMap[t] = pt
+	return pt, nil
+}
+
+// parseRequestType preprocesses the given type
+// into a form that can be efficiently interpreted
+// by Unmarshal.
+func parseRequestType(t reflect.Type) (*requestType, error) {
+	if t.Kind() != reflect.Ptr || t.Elem().Kind() != reflect.Struct {
+		return nil, fmt.Errorf("type is not pointer to struct")
+	}
+	hasBody := false
+	var pt requestType
+	for _, f := range fields(t.Elem()) {
+		tag, err := parseTag(f.Tag, f.Name)
+		if err != nil {
+			return nil, errgo.Notef(err, "bad tag %q in field %s", f.Tag, f.Name)
+		}
+		if tag.source == sourceBody {
+			if hasBody {
+				return nil, errgo.New("more than one body field specified")
+			}
+			hasBody = true
+		}
+		field := field{
+			index: f.Index,
+		}
+		if f.Type.Kind() == reflect.Ptr {
+			// The field is a pointer, so when the value is set,
+			// we need to create a new pointer to put
+			// it into.
+			field.makeResult = makePointerResult
+			f.Type = f.Type.Elem()
+		} else {
+			field.makeResult = makeValueResult
+		}
+		field.unmarshal, err = getUnmarshaler(tag, f.Type)
+		if err != nil {
+			return nil, errgo.Mask(err)
+		}
+		if f.Anonymous {
+			if tag.source != sourceBody && tag.source != sourceNone {
+				return nil, errgo.New("httprequest tag not yet supported on anonymous fields")
+			}
+		}
+		pt.fields = append(pt.fields, field)
+	}
+	return &pt, nil
+}
+
+func makePointerResult(v reflect.Value) reflect.Value {
+	if v.IsNil() {
+		v.Set(reflect.New(v.Type().Elem()))
+	}
+	return v.Elem()
+}
+
+func makeValueResult(v reflect.Value) reflect.Value {
+	return v
+}
+
+// getUnmarshaler returns an unmarshaler function
+// suitable for unmarshaling a field with the given tag
+// into a value of the given type.
+func getUnmarshaler(tag tag, t reflect.Type) (unmarshaler, error) {
+	switch {
+	case tag.source == sourceNone:
+		return unmarshalNop, nil
+	case tag.source == sourceBody:
+		return unmarshalBody, nil
+	case t == reflect.TypeOf([]string(nil)):
+		if tag.source != sourceForm {
+			return nil, errgo.New("invalid target type []string for path parameter")
+		}
+		return unmarshalAllField(tag.name), nil
+	case t == reflect.TypeOf(""):
+		return unmarshalString(tag), nil
+	case implementsTextUnmarshaler(t):
+		return unmarshalWithUnmarshalText(t, tag), nil
+	default:
+		return unmarshalWithScan(tag), nil
+	}
+}
+
+// unmarshalNop just creates the result value but does not
+// fill it out with anything. This is used to create pointers
+// to new anonymous field members.
+func unmarshalNop(v reflect.Value, p Params, makeResult resultMaker) error {
+	makeResult(v)
+	return nil
+}
+
+// unmarshalAllField unmarshals all the form fields for a given
+// attribute into a []string slice.
+func unmarshalAllField(name string) unmarshaler {
+	return func(v reflect.Value, p Params, makeResult resultMaker) error {
+		vals := p.Form[name]
+		if len(vals) > 0 {
+			makeResult(v).Set(reflect.ValueOf(vals))
+		}
+		return nil
+	}
+}
+
+// unmarshalString unmarshals into a string field.
+func unmarshalString(tag tag) unmarshaler {
+	getVal := formGetters[tag.source]
+	if getVal == nil {
+		panic("unexpected source")
+	}
+	return func(v reflect.Value, p Params, makeResult resultMaker) error {
+		val, ok := getVal(tag.name, p)
+		if ok {
+			makeResult(v).Set(reflect.ValueOf(val))
+		}
+		return nil
+	}
+}
+
+// unmarshalBody unmarshals the http request body
+// into the given value.
+func unmarshalBody(v reflect.Value, p Params, makeResult resultMaker) error {
+	data, err := ioutil.ReadAll(p.Body)
+	if err != nil {
+		return errgo.Notef(err, "cannot read request body")
+	}
+	// TODO allow body types that aren't necessarily JSON.
+	result := makeResult(v)
+	if err := json.Unmarshal(data, result.Addr().Interface()); err != nil {
+		return errgo.Notef(err, "cannot unmarshal request body")
+	}
+	return nil
+}
+
+// formGetters maps from source to a function that
+// returns the value for a given key and reports
+// whether the value was found.
+var formGetters = []func(name string, p Params) (string, bool){
+	sourceForm: func(name string, p Params) (string, bool) {
+		vs := p.Form[name]
+		if len(vs) == 0 {
+			return "", false
+		}
+		return vs[0], true
+	},
+	sourcePath: func(name string, p Params) (string, bool) {
+		for _, pv := range p.PathVar {
+			if pv.Key == name {
+				return pv.Value, true
+			}
+		}
+		return "", false
+	},
+	sourceBody: nil,
+}
+
+var textUnmarshalerType = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
+
+func implementsTextUnmarshaler(t reflect.Type) bool {
+	// Use the pointer type, because a pointer
+	// type will implement a superset of the methods
+	// of a non-pointer type.
+	return reflect.PtrTo(t).Implements(textUnmarshalerType)
+}
+
+// unmarshalWithUnmarshalText returns an unmarshaler
+// that unmarshals the given type from the given tag
+// using its UnmarshalText method.
+func unmarshalWithUnmarshalText(t reflect.Type, tag tag) unmarshaler {
+	m, ok := reflect.PtrTo(t).MethodByName("UnmarshalText")
+	if !ok {
+		panic("UnmarshalText not found!")
+	}
+	getVal := formGetters[tag.source]
+	if getVal == nil {
+		panic("unexpected source")
+	}
+	return func(v reflect.Value, p Params, makeResult resultMaker) error {
+		val, _ := getVal(tag.name, p)
+		method := makeResult(v).Addr().Method(m.Index)
+		args := []reflect.Value{reflect.ValueOf([]byte(val))}
+		out := method.Call(args)[0]
+		if out.IsNil() {
+			return nil
+		}
+		// There's an error, so return it.
+		return out.Interface().(error)
+	}
+}
+
+// unmarshalWithScan returns an unmarshaler
+// that unmarshals the given tag using fmt.Scan.
+func unmarshalWithScan(tag tag) unmarshaler {
+	formGet := formGetters[tag.source]
+	if formGet == nil {
+		panic("unexpected source")
+	}
+	return func(v reflect.Value, p Params, makeResult resultMaker) error {
+		val, ok := formGet(tag.name, p)
+		if !ok {
+			// TODO allow specifying that a field is mandatory?
+			return nil
+		}
+		_, err := fmt.Sscan(val, makeResult(v).Addr().Interface())
+		if err != nil {
+			return errgo.Notef(err, "cannot parse %q into %s", val, v.Type())
+		}
+		return nil
+	}
+}
+
+type tagSource uint8
+
+const (
+	sourceNone = iota
+	sourcePath
+	sourceForm
+	sourceBody
+)
+
+type tag struct {
+	name   string
+	source tagSource
+}
+
+// parseTag parses the given struct tag attached to the given
+// field name into a tag structure.
+func parseTag(rtag reflect.StructTag, fieldName string) (tag, error) {
+	t := tag{
+		name: fieldName,
+	}
+	tagStr := rtag.Get("httprequest")
+	if tagStr == "" {
+		return t, nil
+	}
+	fields := strings.Split(tagStr, ",")
+	if fields[0] != "" {
+		t.name = fields[0]
+	}
+	for _, f := range fields[1:] {
+		switch f {
+		case "path":
+			t.source = sourcePath
+		case "form":
+			t.source = sourceForm
+		case "body":
+			t.source = sourceBody
+		default:
+			return tag{}, fmt.Errorf("unknown tag flag %q", f)
+		}
+	}
+	return t, nil
+}
+
+// fields returns all the fields in the given struct type
+// including fields inside anonymous struct members.
+// The fields are ordered with top level fields first
+// followed by the members of those fields
+// for anonymous fields.
+func fields(t reflect.Type) []reflect.StructField {
+	byName := make(map[string]reflect.StructField)
+	addFields(t, byName, nil)
+	fields := make(fieldsByIndex, 0, len(byName))
+	for _, f := range byName {
+		if f.Name != "" {
+			fields = append(fields, f)
+		}
+	}
+	sort.Sort(fields)
+	return fields
+}
+
+func addFields(t reflect.Type, byName map[string]reflect.StructField, index []int) {
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		index := append(index, i)
+		var add bool
+		old, ok := byName[f.Name]
+		switch {
+		case ok && len(old.Index) == len(index):
+			// Fields with the same name at the same depth
+			// cancel one another out. Set the field name
+			// to empty to signify that has happened.
+			old.Name = ""
+			byName[f.Name] = old
+			add = false
+		case ok:
+			// Fields at less depth win.
+			add = len(index) < len(old.Index)
+		default:
+			// The field did not previously exist.
+			add = true
+		}
+		if add {
+			// copy the index so that it's not overwritten
+			// by the other appends.
+			f.Index = append([]int(nil), index...)
+			byName[f.Name] = f
+		}
+		if f.Anonymous {
+			if f.Type.Kind() == reflect.Ptr {
+				f.Type = f.Type.Elem()
+			}
+			addFields(f.Type, byName, index)
+		}
+	}
+}
+
+type fieldsByIndex []reflect.StructField
+
+func (f fieldsByIndex) Len() int {
+	return len(f)
+}
+
+func (f fieldsByIndex) Swap(i, j int) {
+	f[i], f[j] = f[j], f[i]
+}
+
+func (f fieldsByIndex) Less(i, j int) bool {
+	indexi, indexj := f[i].Index, f[j].Index
+	for len(indexi) != 0 && len(indexj) != 0 {
+		ii, ij := indexi[0], indexj[0]
+		if ii != ij {
+			return ii < ij
+		}
+		indexi, indexj = indexi[1:], indexj[1:]
+	}
+	return len(indexi) < len(indexj)
+}

--- a/type_test.go
+++ b/type_test.go
@@ -1,0 +1,576 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package httprequest
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+
+	jc "github.com/juju/testing/checkers"
+	"github.com/julienschmidt/httprouter"
+	gc "gopkg.in/check.v1"
+)
+
+type testSuite struct{}
+
+var _ = gc.Suite(&testSuite{})
+
+func body(s string) io.ReadCloser {
+	return ioutil.NopCloser(strings.NewReader(s))
+}
+
+var unmarshalTests = []struct {
+	about       string
+	val         interface{}
+	expect      interface{}
+	params      Params
+	expectError string
+}{{
+	about: "struct with simple fields",
+	val: struct {
+		F1          int    `httprequest:",form"`
+		F2          int    `httprequest:",form"`
+		G1          string `httprequest:",path"`
+		G2          string `httprequest:",path"`
+		H           string `httprequest:",body"`
+		UnknownForm string `httprequest:",form"`
+		UnknownPath string `httprequest:",path"`
+	}{
+		F1: 99,
+		F2: -35,
+		G1: "g1 val",
+		G2: "g2 val",
+		H:  "h val",
+	},
+	params: Params{
+		Request: &http.Request{
+			Form: url.Values{
+				"F1": {"99"},
+				"F2": {"-35", "not a number"},
+			},
+			Body: body(`"h val"`),
+		},
+		PathVar: httprouter.Params{{
+			Key:   "G2",
+			Value: "g2 val",
+		}, {
+			Key:   "G1",
+			Value: "g1 val",
+		}, {
+			Key:   "G1",
+			Value: "g1 wrong val",
+		}},
+	},
+}, {
+	about: "struct with renamed fields",
+	val: struct {
+		F1 int    `httprequest:"x1,form"`
+		F2 int    `httprequest:"x2,form"`
+		G1 string `httprequest:"g1,path"`
+		G2 string `httprequest:"g2,path"`
+	}{
+		F1: 99,
+		F2: -35,
+		G1: "g1 val",
+		G2: "g2 val",
+	},
+	params: Params{
+		Request: &http.Request{
+			Form: url.Values{
+				"x1": {"99"},
+				"x2": {"-35", "not a number"},
+			},
+		},
+		PathVar: httprouter.Params{{
+			Key:   "g2",
+			Value: "g2 val",
+		}, {
+			Key:   "g1",
+			Value: "g1 val",
+		}, {
+			Key:   "g1",
+			Value: "g1 wrong val",
+		}},
+	},
+}, {
+	about: "fields without httprequest tags are ignored",
+	val: struct {
+		F int
+	}{},
+	params: Params{
+		Request: &http.Request{
+			Form: url.Values{
+				"F": {"foo"},
+			},
+		},
+		PathVar: httprouter.Params{{
+			Key:   "F",
+			Value: "foo",
+		}},
+	},
+}, {
+	about: "pointer fields are filled out",
+	val: struct {
+		F *int `httprequest:",form"`
+		*SFG
+		S *string `httprequest:",form"`
+		T *string `httprequest:",form"`
+	}{
+		F: newInt(99),
+		SFG: &SFG{
+			F: 0,
+			G: 534,
+		},
+		S: newString("s val"),
+	},
+	params: Params{
+		Request: &http.Request{
+			Form: url.Values{
+				"F": {"99"},
+				"G": {"534"},
+				"S": {"s val"},
+			},
+		},
+	},
+}, {
+	about: "UnmarshalText called on TextUnmarshalers",
+	val: struct {
+		F  exclamationUnmarshaler  `httprequest:",form"`
+		G  exclamationUnmarshaler  `httprequest:",path"`
+		FP *exclamationUnmarshaler `httprequest:",form"`
+	}{
+		F:  "yes!",
+		G:  "no!",
+		FP: (*exclamationUnmarshaler)(newString("maybe!")),
+	},
+	params: Params{
+		Request: &http.Request{
+			Form: url.Values{
+				"F":  {"yes"},
+				"FP": {"maybe"},
+			},
+		},
+		PathVar: httprouter.Params{{
+			Key:   "G",
+			Value: "no",
+		}},
+	},
+}, {
+	about: "UnmarshalText not called on values with a non-TextUnmarshaler UnmarshalText method",
+	val: struct {
+		F notTextUnmarshaler `httprequest:",form"`
+	}{
+		F: "hello",
+	},
+	params: Params{
+		Request: &http.Request{
+			Form: url.Values{
+				"F": {"hello"},
+			},
+		},
+	},
+}, {
+	about: "UnmarshalText returning an error",
+	val: struct {
+		F exclamationUnmarshaler `httprequest:",form"`
+	}{},
+	params: Params{
+		Request: &http.Request{},
+	},
+	expectError: "empty string!",
+}, {
+	about: "all field form values",
+	val: struct {
+		A []string  `httprequest:",form"`
+		B *[]string `httprequest:",form"`
+		C []string  `httprequest:",form"`
+		D *[]string `httprequest:",form"`
+	}{
+		A: []string{"a1", "a2"},
+		B: func() *[]string {
+			x := []string{"b1", "b2", "b3"}
+			return &x
+		}(),
+	},
+	params: Params{
+		Request: &http.Request{
+			Form: url.Values{
+				"A": {"a1", "a2"},
+				"B": {"b1", "b2", "b3"},
+			},
+		},
+	},
+}, {
+	about: "invalid scan field",
+	val: struct {
+		A int `httprequest:",form"`
+	}{},
+	params: Params{
+		Request: &http.Request{
+			Form: url.Values{
+				"A": {"not an int"},
+			},
+		},
+	},
+	expectError: `cannot parse "not an int" into int: expected integer`,
+}, {
+	about: "scan field not present",
+	val: struct {
+		A int `httprequest:",form"`
+	}{},
+	params: Params{
+		Request: &http.Request{},
+	},
+}, {
+	about: "invalid JSON body",
+	val: struct {
+		A string `httprequest:",body"`
+	}{},
+	params: Params{
+		Request: &http.Request{
+			Body: body("invalid JSON"),
+		},
+	},
+	expectError: "cannot unmarshal request body: invalid character 'i' looking for beginning of value",
+}, {
+	about: "body with read error",
+	val: struct {
+		A string `httprequest:",body"`
+	}{},
+	params: Params{
+		Request: &http.Request{
+			Body: errorReader("some error"),
+		},
+	},
+	expectError: "cannot read request body: some error",
+}, {
+	about: "[]string not allowed for URL source",
+	val: struct {
+		A []string `httprequest:",path"`
+	}{},
+	expectError: `bad type .*: invalid target type \[]string for path parameter`,
+}, {
+	about: "duplicated body",
+	val: struct {
+		B1 int    `httprequest:",body"`
+		B2 string `httprequest:",body"`
+	}{},
+	expectError: "bad type .*: more than one body field specified",
+}, {
+	about: "body tag name is ignored",
+	val: struct {
+		B string `httprequest:"foo,body"`
+	}{
+		B: "hello",
+	},
+	params: Params{
+		Request: &http.Request{
+			Body: body(`"hello"`),
+		},
+	},
+}, {
+	about: "tag with invalid source",
+	val: struct {
+		B1 int `httprequest:",xxx"`
+	}{},
+	expectError: `bad type .*: bad tag "httprequest:\\",xxx\\"" in field B1: unknown tag flag "xxx"`,
+}, {
+	about:       "non-struct pointer",
+	val:         0,
+	expectError: `bad type \*int: type is not pointer to struct`,
+}}
+
+func (*testSuite) TestUnmarshal(c *gc.C) {
+	for i, test := range unmarshalTests {
+		c.Logf("%d: %s", i, test.about)
+		t := reflect.TypeOf(test.val)
+		fillv := reflect.New(t)
+		err := Unmarshal(test.params, fillv.Interface())
+		if test.expectError != "" {
+			c.Assert(err, gc.ErrorMatches, test.expectError)
+			continue
+		}
+		c.Assert(fillv.Elem().Interface(), jc.DeepEquals, test.val)
+	}
+}
+
+type notTextUnmarshaler string
+
+// UnmarshalText does *not* implement encoding.TextUnmarshaler
+// (it has no arguments or error return value)
+func (t *notTextUnmarshaler) UnmarshalText() {
+	panic("unexpected call")
+}
+
+type exclamationUnmarshaler string
+
+func (t *exclamationUnmarshaler) UnmarshalText(b []byte) error {
+	if len(b) == 0 {
+		return fmt.Errorf("empty string!")
+	}
+	*t = exclamationUnmarshaler(b) + "!"
+	return nil
+}
+
+// TODO non-pointer struct
+
+type structField struct {
+	name  string
+	index []int
+}
+
+var fieldsTests = []struct {
+	about  string
+	val    interface{}
+	expect []structField
+}{{
+	about: "simple struct",
+	val: struct {
+		A int
+		B string
+		C bool
+	}{},
+	expect: []structField{{
+		name:  "A",
+		index: []int{0},
+	}, {
+		name:  "B",
+		index: []int{1},
+	}, {
+		name:  "C",
+		index: []int{2},
+	}},
+}, {
+	about: "non-embedded struct member",
+	val: struct {
+		A struct {
+			X int
+		}
+	}{},
+	expect: []structField{{
+		name:  "A",
+		index: []int{0},
+	}},
+}, {
+	about: "embedded exported struct",
+	val: struct {
+		SFG
+	}{},
+	expect: []structField{{
+		name:  "SFG",
+		index: []int{0},
+	}, {
+		name:  "F",
+		index: []int{0, 0},
+	}, {
+		name:  "G",
+		index: []int{0, 1},
+	}},
+}, {
+	about: "embedded unexported struct",
+	val: struct {
+		sFG
+	}{},
+	expect: []structField{{
+		name:  "sFG",
+		index: []int{0},
+	}, {
+		name:  "F",
+		index: []int{0, 0},
+	}, {
+		name:  "G",
+		index: []int{0, 1},
+	}},
+}, {
+	about: "two embedded structs with cancelling members",
+	val: struct {
+		SFG
+		SF
+	}{},
+	expect: []structField{{
+		name:  "SFG",
+		index: []int{0},
+	}, {
+		name:  "G",
+		index: []int{0, 1},
+	}, {
+		name:  "SF",
+		index: []int{1},
+	}},
+}, {
+	about: "embedded structs with same fields at different depths",
+	val: struct {
+		SFGH3
+		SG1
+		SFG2
+		SF2
+		L int
+	}{},
+	expect: []structField{{
+		name:  "SFGH3",
+		index: []int{0},
+	}, {
+		name:  "SFGH2",
+		index: []int{0, 0},
+	}, {
+		name:  "SFGH1",
+		index: []int{0, 0, 0},
+	}, {
+		name:  "SFGH",
+		index: []int{0, 0, 0, 0},
+	}, {
+		name:  "H",
+		index: []int{0, 0, 0, 0, 2},
+	}, {
+		name:  "SG1",
+		index: []int{1},
+	}, {
+		name:  "SG",
+		index: []int{1, 0},
+	}, {
+		name:  "G",
+		index: []int{1, 0, 0},
+	}, {
+		name:  "SFG2",
+		index: []int{2},
+	}, {
+		name:  "SFG1",
+		index: []int{2, 0},
+	}, {
+		name:  "SFG",
+		index: []int{2, 0, 0},
+	}, {
+		name:  "SF2",
+		index: []int{3},
+	}, {
+		name:  "SF1",
+		index: []int{3, 0},
+	}, {
+		name:  "SF",
+		index: []int{3, 0, 0},
+	}, {
+		name:  "L",
+		index: []int{4},
+	}},
+}, {
+	about: "embedded pointer struct",
+	val: struct {
+		*SF
+	}{},
+	expect: []structField{{
+		name:  "SF",
+		index: []int{0},
+	}, {
+		name:  "F",
+		index: []int{0, 0},
+	}},
+}}
+
+type SFG struct {
+	F int `httprequest:",form"`
+	G int `httprequest:",form"`
+}
+
+type SFG1 struct {
+	SFG
+}
+
+type SFG2 struct {
+	SFG1
+}
+
+type SFGH struct {
+	F int `httprequest:",form"`
+	G int `httprequest:",form"`
+	H int `httprequest:",form"`
+}
+
+type SFGH1 struct {
+	SFGH
+}
+
+type SFGH2 struct {
+	SFGH1
+}
+
+type SFGH3 struct {
+	SFGH2
+}
+
+type SF struct {
+	F int `httprequest:",form"`
+}
+
+type SF1 struct {
+	SF
+}
+
+type SF2 struct {
+	SF1
+}
+
+type SG struct {
+	G int `httprequest:",form"`
+}
+
+type SG1 struct {
+	SG
+}
+
+type sFG struct {
+	F int `httprequest:",form"`
+	G int `httprequest:",form"`
+}
+
+func (*testSuite) TestFields(c *gc.C) {
+	for i, test := range fieldsTests {
+		c.Logf("%d: %s", i, test.about)
+		t := reflect.TypeOf(test.val)
+		got := fields(t)
+		c.Assert(got, gc.HasLen, len(test.expect))
+		for j, field := range got {
+			expect := test.expect[j]
+			c.Logf("field %d: %s", j, expect.name)
+			gotField := t.FieldByIndex(field.Index)
+			// Unfortunately, FieldByIndex does not return
+			// a field with the same index that we passed in,
+			// so we set it to the expected value so that
+			// it can be compared later with the result of FieldByName.
+			gotField.Index = field.Index
+			expectField := t.FieldByIndex(expect.index)
+			// ditto.
+			expectField.Index = expect.index
+			c.Assert(gotField, jc.DeepEquals, expectField)
+
+			// Sanity check that we can actually access the field by the
+			// expected name.
+			expectField1, ok := t.FieldByName(expect.name)
+			c.Assert(ok, jc.IsTrue)
+			c.Assert(expectField1, jc.DeepEquals, expectField)
+		}
+	}
+}
+
+func newInt(i int) *int {
+	return &i
+}
+
+func newString(s string) *string {
+	return &s
+}
+
+type errorReader string
+
+func (r errorReader) Read([]byte) (int, error) {
+	return 0, fmt.Errorf("%s", r)
+}
+
+func (r errorReader) Close() error {
+	return nil
+}


### PR DESCRIPTION
This is the start of a package that is intended to reduce boilerplate
parsing code in HTTP request handlers. The request parameters
are specified as struct fields with tags that specify where the
parameter should be taken from.

Here's an example it might be used (taking as an example some code from
the changes/published path in the charm store):

```
router := httprouter.New()
router.GET(":id/changes/published", func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
    var params struct {
          Id string    `httprequest:"id,url"`
          Limit int    `httprequest:"limit,form"`
          From dateTime   `httprequest:"from,form"`
          To dateTime       `httprequest:"to,form"`
    }
    if err := httprequest.Unmarshal(httprequest.Params{
         Request: req,
         Path: httprouter.Params,
     }; err != nil {
         // return error
     }
     // do stuff with parameters.
})

type dateTime struct {
    time.Time
 }
 func (dt *dateTime) UnmarshalText(b []byte) (err error) {
      dt.t, err = time.Parse("2006-01-02", string(b))
      return
 }
```

The next stage (as yet to be written) is to provide a function
that can convert from a handler method of the form:

```
func(w http.RequestWriter, p httprequest.Params, arg someType)
```

into an httprouter.Handle function, which would remove the Unmarshal
error checking boilerplate from the above example.

Almost all of the heavy lifting is implemented by the Unmarshal function.
