### PR TITLE
add handle benchmarks

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -4,17 +4,183 @@
 package httprequest_test
 
 import (
+	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/juju/httprequest"
 	"github.com/julienschmidt/httprouter"
+	"gopkg.in/errgo.v1"
 )
 
 const dateFormat = "2006-01-02"
+
+type testResult struct {
+	Key   string `json:",omitempty"`
+	Date  string `json:",omitempty"`
+	Count int64
+}
+
+type testParams2Fields struct {
+	Id    string `httprequest:"id,path"`
+	Limit int    `httprequest:"limit,form"`
+}
+
+type testParams4Fields struct {
+	Id    string   `httprequest:"id,path"`
+	Limit int      `httprequest:"limit,form"`
+	From  dateTime `httprequest:"from,form"`
+	To    dateTime `httprequest:"to,form"`
+}
+
+type dateTime struct {
+	time.Time
+}
+
+func (dt *dateTime) UnmarshalText(b []byte) (err error) {
+	dt.Time, err = time.Parse(dateFormat, string(b))
+	return
+}
+
+type testParams2StringFields struct {
+	Field0 string `httprequest:",form"`
+	Field1 string `httprequest:",form"`
+}
+
+type testParams4StringFields struct {
+	Field0 string `httprequest:",form"`
+	Field1 string `httprequest:",form"`
+	Field2 string `httprequest:",form"`
+	Field3 string `httprequest:",form"`
+}
+
+type testParams8StringFields struct {
+	Field0 string `httprequest:",form"`
+	Field1 string `httprequest:",form"`
+	Field2 string `httprequest:",form"`
+	Field3 string `httprequest:",form"`
+	Field4 string `httprequest:",form"`
+	Field5 string `httprequest:",form"`
+	Field6 string `httprequest:",form"`
+	Field7 string `httprequest:",form"`
+}
+
+type testParams16StringFields struct {
+	Field0  string `httprequest:",form"`
+	Field1  string `httprequest:",form"`
+	Field2  string `httprequest:",form"`
+	Field3  string `httprequest:",form"`
+	Field4  string `httprequest:",form"`
+	Field5  string `httprequest:",form"`
+	Field6  string `httprequest:",form"`
+	Field7  string `httprequest:",form"`
+	Field8  string `httprequest:",form"`
+	Field9  string `httprequest:",form"`
+	Field10 string `httprequest:",form"`
+	Field11 string `httprequest:",form"`
+	Field12 string `httprequest:",form"`
+	Field13 string `httprequest:",form"`
+	Field14 string `httprequest:",form"`
+	Field15 string `httprequest:",form"`
+}
+
+func BenchmarkUnmarshal2Fields(b *testing.B) {
+	params := httprequest.Params{
+		Request: &http.Request{
+			Form: url.Values{
+				"limit": {"2000"},
+			},
+		},
+		PathVar: httprouter.Params{{
+			Key:   "id",
+			Value: "someid",
+		}},
+	}
+	var arg testParams2Fields
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		arg = testParams2Fields{}
+		err := httprequest.Unmarshal(params, &arg)
+		if err != nil {
+			b.Fatalf("unmarshal failed: %v", err)
+		}
+	}
+	b.StopTimer()
+	if !reflect.DeepEqual(arg, testParams2Fields{
+		Id:    "someid",
+		Limit: 2000,
+	}) {
+		b.Errorf("unexpected result: got %#v", arg)
+	}
+}
+
+func BenchmarkHandle2FieldsTrad(b *testing.B) {
+	results := []testResult{}
+	benchmarkHandle2Fields(b, errorMapper.HandleJSON(func(h http.Header, p httprequest.Params) (interface{}, error) {
+		limit := -1
+		if limitStr := p.Form.Get("limit"); limitStr != "" {
+			var err error
+			limit, err = strconv.Atoi(limitStr)
+			if err != nil || limit <= 0 {
+				panic("unreachable")
+			}
+		}
+		if id := p.PathVar.ByName("id"); id == "" {
+			panic("unreachable")
+		}
+		return results, nil
+	}))
+}
+
+func BenchmarkHandle2Fields(b *testing.B) {
+	results := []testResult{}
+	benchmarkHandle2Fields(b, errorMapper.Handle(func(h http.Header, p httprequest.Params, arg *testParams2Fields) ([]testResult, error) {
+		if arg.Limit <= 0 {
+			panic("unreachable")
+		}
+		return results, nil
+	}))
+}
+
+func BenchmarkHandle2FieldsUnmarshalOnly(b *testing.B) {
+	results := []testResult{}
+	benchmarkHandle2Fields(b, errorMapper.HandleJSON(func(h http.Header, p httprequest.Params) (interface{}, error) {
+		var arg testParams2Fields
+		if err := httprequest.Unmarshal(p, &arg); err != nil {
+			return nil, err
+		}
+		if arg.Limit <= 0 {
+			panic("unreachable")
+		}
+		return results, nil
+	}))
+}
+
+func benchmarkHandle2Fields(b *testing.B, handle func(w http.ResponseWriter, req *http.Request, pvar httprouter.Params)) {
+	rec := httptest.NewRecorder()
+	params := httprequest.Params{
+		Request: &http.Request{
+			Form: url.Values{
+				"limit": {"2000"},
+			},
+		},
+		PathVar: httprouter.Params{{
+			Key:   "id",
+			Value: "someid",
+		}},
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rec.Body.Reset()
+		handle(rec, params.Request, params.PathVar)
+	}
+}
 
 func BenchmarkUnmarshal4Fields(b *testing.B) {
 	fromDate, err1 := time.Parse(dateFormat, "2010-10-10")
@@ -22,12 +188,7 @@ func BenchmarkUnmarshal4Fields(b *testing.B) {
 	if err1 != nil || err2 != nil {
 		b.Fatalf("bad times")
 	}
-	type P struct {
-		Id    string   `httprequest:"id,path"`
-		Limit int      `httprequest:"limit,form"`
-		From  dateTime `httprequest:"from,form"`
-		To    dateTime `httprequest:"to,form"`
-	}
+	type P testParams4Fields
 	params := httprequest.Params{
 		Request: &http.Request{
 			Form: url.Values{
@@ -62,11 +223,233 @@ func BenchmarkUnmarshal4Fields(b *testing.B) {
 	}
 }
 
-type dateTime struct {
-	time.Time
+func BenchmarkHandle4FieldsTrad(b *testing.B) {
+	results := []testResult{}
+	benchmarkHandle4Fields(b, errorMapper.HandleJSON(func(h http.Header, p httprequest.Params) (interface{}, error) {
+		start, stop, err := parseDateRange(p.Form)
+		if err != nil {
+			panic("unreachable")
+		}
+		_ = start
+		_ = stop
+		limit := -1
+		if limitStr := p.Form.Get("limit"); limitStr != "" {
+			limit, err = strconv.Atoi(limitStr)
+			if err != nil || limit <= 0 {
+				panic("unreachable")
+			}
+		}
+		if id := p.PathVar.ByName("id"); id == "" {
+			panic("unreachable")
+		}
+		return results, nil
+	}))
 }
 
-func (dt *dateTime) UnmarshalText(b []byte) (err error) {
-	dt.Time, err = time.Parse(dateFormat, string(b))
+// parseDateRange parses a date range as specified in an http
+// request. The returned times will be zero if not specified.
+func parseDateRange(form url.Values) (start, stop time.Time, err error) {
+	if v := form.Get("start"); v != "" {
+		var err error
+		start, err = time.Parse(dateFormat, v)
+		if err != nil {
+			return time.Time{}, time.Time{}, errgo.Newf("invalid 'start' value %q", v)
+		}
+	}
+	if v := form.Get("stop"); v != "" {
+		var err error
+		stop, err = time.Parse(dateFormat, v)
+		if err != nil {
+			return time.Time{}, time.Time{}, errgo.Newf("invalid 'stop' value %q", v)
+		}
+		// Cover all timestamps within the stop day.
+		stop = stop.Add(24*time.Hour - 1*time.Second)
+	}
 	return
+}
+
+func BenchmarkHandle4Fields(b *testing.B) {
+	results := []testResult{}
+	benchmarkHandle4Fields(b, errorMapper.Handle(func(h http.Header, p httprequest.Params, arg *testParams4Fields) ([]testResult, error) {
+		if arg.To.Before(arg.From.Time) {
+			panic("unreachable")
+		}
+		if arg.Limit <= 0 {
+			panic("unreachable")
+		}
+		return results, nil
+	}))
+}
+
+func BenchmarkHandle4FieldsUnmarshalOnly(b *testing.B) {
+	results := []testResult{}
+	benchmarkHandle4Fields(b, errorMapper.HandleJSON(func(h http.Header, p httprequest.Params) (interface{}, error) {
+		var arg testParams4Fields
+		if err := httprequest.Unmarshal(p, &arg); err != nil {
+			return nil, err
+		}
+		if arg.To.Before(arg.From.Time) {
+			panic("unreachable")
+		}
+		if arg.Limit <= 0 {
+			panic("unreachable")
+		}
+		return results, nil
+	}))
+}
+
+func benchmarkHandle4Fields(b *testing.B, handle func(w http.ResponseWriter, req *http.Request, pvar httprouter.Params)) {
+	// example taken from charmstore changes/published endpoint
+	fromDate, err1 := time.Parse(dateFormat, "2010-10-10")
+	toDate, err2 := time.Parse(dateFormat, "2011-11-11")
+	if err1 != nil || err2 != nil {
+		b.Fatalf("bad times")
+	}
+	rec := httptest.NewRecorder()
+	params := httprequest.Params{
+		Request: &http.Request{
+			Form: url.Values{
+				"limit": {"2000"},
+				"from":  {fromDate.Format(dateFormat)},
+				"to":    {toDate.Format(dateFormat)},
+			},
+		},
+		PathVar: httprouter.Params{{
+			Key:   "id",
+			Value: "someid",
+		}},
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rec.Body.Reset()
+		handle(rec, params.Request, params.PathVar)
+	}
+}
+
+func BenchmarkHandle2StringFields(b *testing.B) {
+	benchmarkHandleNFields(b, 2, errorMapper.Handle(func(h http.ResponseWriter, p httprequest.Params, arg *testParams2StringFields) error {
+		return nil
+	}))
+}
+
+func BenchmarkHandle2StringFieldsUnmarshalOnly(b *testing.B) {
+	benchmarkHandleNFields(b, 2, errorMapper.HandleErrors(func(w http.ResponseWriter, p httprequest.Params) error {
+		var arg testParams2StringFields
+		return httprequest.Unmarshal(p, &arg)
+	}))
+}
+
+func BenchmarkHandle2StringFieldsTrad(b *testing.B) {
+	benchmarkHandleNFields(b, 2, errorMapper.HandleErrors(func(w http.ResponseWriter, p httprequest.Params) error {
+		var arg testParams2StringFields
+		arg.Field0 = p.Form.Get("Field0")
+		arg.Field1 = p.Form.Get("Field1")
+		return nil
+	}))
+}
+
+func BenchmarkHandle4StringFields(b *testing.B) {
+	benchmarkHandleNFields(b, 4, errorMapper.Handle(func(h http.ResponseWriter, p httprequest.Params, arg *testParams4StringFields) error {
+		return nil
+	}))
+}
+
+func BenchmarkHandle4StringFieldsUnmarshalOnly(b *testing.B) {
+	benchmarkHandleNFields(b, 4, errorMapper.HandleErrors(func(w http.ResponseWriter, p httprequest.Params) error {
+		var arg testParams4StringFields
+		return httprequest.Unmarshal(p, &arg)
+	}))
+}
+
+func BenchmarkHandle4StringFieldsTrad(b *testing.B) {
+	benchmarkHandleNFields(b, 4, errorMapper.HandleErrors(func(w http.ResponseWriter, p httprequest.Params) error {
+		var arg testParams4StringFields
+		arg.Field0 = p.Form.Get("Field0")
+		arg.Field1 = p.Form.Get("Field1")
+		arg.Field2 = p.Form.Get("Field2")
+		arg.Field3 = p.Form.Get("Field3")
+		return nil
+	}))
+}
+
+func BenchmarkHandle8StringFields(b *testing.B) {
+	benchmarkHandleNFields(b, 8, errorMapper.Handle(func(h http.ResponseWriter, p httprequest.Params, arg *testParams8StringFields) error {
+		return nil
+	}))
+}
+
+func BenchmarkHandle8StringFieldsUnmarshalOnly(b *testing.B) {
+	benchmarkHandleNFields(b, 8, errorMapper.HandleErrors(func(w http.ResponseWriter, p httprequest.Params) error {
+		var arg testParams8StringFields
+		return httprequest.Unmarshal(p, &arg)
+	}))
+}
+
+func BenchmarkHandle8StringFieldsTrad(b *testing.B) {
+	benchmarkHandleNFields(b, 8, errorMapper.HandleErrors(func(w http.ResponseWriter, p httprequest.Params) error {
+		var arg testParams8StringFields
+		arg.Field0 = p.Form.Get("Field0")
+		arg.Field1 = p.Form.Get("Field1")
+		arg.Field2 = p.Form.Get("Field2")
+		arg.Field3 = p.Form.Get("Field3")
+		arg.Field4 = p.Form.Get("Field4")
+		arg.Field5 = p.Form.Get("Field5")
+		arg.Field6 = p.Form.Get("Field6")
+		arg.Field7 = p.Form.Get("Field7")
+		return nil
+	}))
+}
+
+func BenchmarkHandle16StringFields(b *testing.B) {
+	benchmarkHandleNFields(b, 16, errorMapper.Handle(func(h http.ResponseWriter, p httprequest.Params, arg *testParams16StringFields) error {
+		return nil
+	}))
+}
+
+func BenchmarkHandle16StringFieldsUnmarshalOnly(b *testing.B) {
+	benchmarkHandleNFields(b, 16, errorMapper.HandleErrors(func(w http.ResponseWriter, p httprequest.Params) error {
+		var arg testParams16StringFields
+		return httprequest.Unmarshal(p, &arg)
+	}))
+}
+
+func BenchmarkHandle16StringFieldsTrad(b *testing.B) {
+	benchmarkHandleNFields(b, 16, errorMapper.HandleErrors(func(w http.ResponseWriter, p httprequest.Params) error {
+		var arg testParams16StringFields
+		arg.Field0 = p.Form.Get("Field0")
+		arg.Field1 = p.Form.Get("Field1")
+		arg.Field2 = p.Form.Get("Field2")
+		arg.Field3 = p.Form.Get("Field3")
+		arg.Field4 = p.Form.Get("Field4")
+		arg.Field5 = p.Form.Get("Field5")
+		arg.Field6 = p.Form.Get("Field6")
+		arg.Field7 = p.Form.Get("Field7")
+		arg.Field8 = p.Form.Get("Field8")
+		arg.Field9 = p.Form.Get("Field9")
+		arg.Field10 = p.Form.Get("Field10")
+		arg.Field11 = p.Form.Get("Field11")
+		arg.Field12 = p.Form.Get("Field12")
+		arg.Field13 = p.Form.Get("Field13")
+		arg.Field14 = p.Form.Get("Field14")
+		arg.Field15 = p.Form.Get("Field15")
+		return nil
+	}))
+}
+
+func benchmarkHandleNFields(b *testing.B, n int, handle func(w http.ResponseWriter, req *http.Request, pvar httprouter.Params)) {
+	form := make(url.Values)
+	for i := 0; i < n; i++ {
+		form[fmt.Sprint("Field", i)] = []string{fmt.Sprintf("field %d", i)}
+	}
+	rec := httptest.NewRecorder()
+	params := httprequest.Params{
+		Request: &http.Request{
+			Form: form,
+		},
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rec.Body.Reset()
+		handle(rec, params.Request, params.PathVar)
+	}
 }

--- a/type.go
+++ b/type.go
@@ -269,7 +269,7 @@ func unmarshalString(tag tag) unmarshaler {
 	return func(v reflect.Value, p Params, makeResult resultMaker) error {
 		val, ok := getVal(tag.name, p)
 		if ok {
-			makeResult(v).Set(reflect.ValueOf(val))
+			makeResult(v).SetString(val)
 		}
 		return nil
 	}


### PR DESCRIPTION
We add a few benchmarks to give us an idea of the costs of this approach
in its various forms. The "Trad" benchmarks show the base cost of the
non-reflective approach.

```
BenchmarkUnmarshal2Fields                  1000000      1951 ns/op      80 B/op       3 allocs/op
BenchmarkHandle2FieldsTrad                 1000000      1357 ns/op     280 B/op       6 allocs/op
BenchmarkHandle2Fields                      300000      5451 ns/op     504 B/op      11 allocs/op
BenchmarkHandle2FieldsUnmarshalOnly         500000      4047 ns/op     392 B/op      10 allocs/op
BenchmarkUnmarshal4Fields                   500000      3765 ns/op     144 B/op       7 allocs/op
BenchmarkHandle4FieldsTrad                 1000000      1390 ns/op     280 B/op       6 allocs/op
BenchmarkHandle4Fields                      200000      7603 ns/op     616 B/op      15 allocs/op
BenchmarkHandle4FieldsUnmarshalOnly         300000      6060 ns/op     504 B/op      14 allocs/op
BenchmarkHandle2StringFields               1000000      1448 ns/op     176 B/op       4 allocs/op
BenchmarkHandle2StringFieldsUnmarshalOnly  3000000       490 ns/op      64 B/op       2 allocs/op
BenchmarkHandle2StringFieldsTrad          10000000       177 ns/op      32 B/op       1 allocs/op
BenchmarkHandle4StringFields               1000000      1673 ns/op     208 B/op       4 allocs/op
BenchmarkHandle4StringFieldsUnmarshalOnly  2000000       683 ns/op      96 B/op       2 allocs/op
BenchmarkHandle4StringFieldsTrad           5000000       246 ns/op      32 B/op       1 allocs/op
BenchmarkHandle8StringFields               1000000      2188 ns/op     272 B/op       4 allocs/op
BenchmarkHandle8StringFieldsUnmarshalOnly  1000000      1226 ns/op     160 B/op       2 allocs/op
BenchmarkHandle8StringFieldsTrad           3000000       472 ns/op      32 B/op       1 allocs/op
BenchmarkHandle16StringFields               500000      2882 ns/op     400 B/op       4 allocs/op
BenchmarkHandle16StringFieldsUnmarshalOnly 1000000      1950 ns/op     288 B/op       2 allocs/op
BenchmarkHandle16StringFieldsTrad          2000000       686 ns/op      32 B/op       1 allocs/op
```
