### PR TITLE
ignore unexported fields in unmarshal type

### DIFF
--- a/type.go
+++ b/type.go
@@ -170,6 +170,11 @@ func parseRequestType(t reflect.Type) (*requestType, error) {
 	hasBody := false
 	var pt requestType
 	for _, f := range fields(t.Elem()) {
+		if f.PkgPath != "" {
+			// Ignore unexported fields (note that this
+			// does not apply to anonymous fields).
+			continue
+		}
 		tag, err := parseTag(f.Tag, f.Name)
 		if err != nil {
 			return nil, errgo.Notef(err, "bad tag %q in field %s", f.Tag, f.Name)

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -102,6 +102,65 @@ var unmarshalTests = []struct {
 		}},
 	},
 }, {
+	about: "unexported fields are ignored",
+	val: struct {
+		f int `httprequest:",form"`
+		G int `httprequest:",form"`
+	}{
+		G: 99,
+	},
+	params: httprequest.Params{
+		Request: &http.Request{
+			Form: url.Values{
+				"G": {"99"},
+				"f": {"100"},
+			},
+		},
+	},
+}, {
+	about: "unexported embedded type works ok",
+	val: struct {
+		sFG
+	}{
+		sFG: sFG{
+			F: 99,
+			G: 100,
+		},
+	},
+	params: httprequest.Params{
+		Request: &http.Request{
+			Form: url.Values{
+				"F": {"99"},
+				"G": {"100"},
+			},
+		},
+	},
+}, {
+	about: "unexported embedded type for body works ok",
+	val: struct {
+		sFG `httprequest:",body"`
+	}{
+		sFG: sFG{
+			F: 99,
+			G: 100,
+		},
+	},
+	params: httprequest.Params{
+		Request: &http.Request{
+			Body: body(`{"F": 99, "G": 100}`),
+		},
+	},
+}, {
+	about: "unexported type for body is ignored",
+	val: struct {
+		foo sFG `httprequest:",body"`
+	}{},
+	params: httprequest.Params{
+		Request: &http.Request{
+			Body: body(`{"F": 99, "G": 100}`),
+		},
+	},
+}, {
 	about: "fields without httprequest tags are ignored",
 	val: struct {
 		F int
@@ -290,6 +349,11 @@ var unmarshalTests = []struct {
 }}
 
 type SFG struct {
+	F int `httprequest:",form"`
+	G int `httprequest:",form"`
+}
+
+type sFG struct {
 	F int `httprequest:",form"`
 	G int `httprequest:",form"`
 }


### PR DESCRIPTION
Previously, if you added an httprequest tag to an unexported field,
you'd get a runtime panic.
