### PR TITLE
Implemented Marshal

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -70,7 +70,7 @@ func checkHandleType(t reflect.Type) (*requestType, error) {
 	if t.In(1) != paramsType {
 		return nil, errgo.Newf("second argument is %s, need %s", t.In(1), paramsType)
 	}
-	pt, err := getRequestType(t.In(2))
+	pt, err := getRequestType(preprocessType{reflectType: t.In(2), purpose: purposeUnmarshal})
 	if err != nil {
 		return nil, errgo.Notef(err, "third argument cannot be used for Unmarshal")
 	}

--- a/handler.go
+++ b/handler.go
@@ -70,7 +70,7 @@ func checkHandleType(t reflect.Type) (*requestType, error) {
 	if t.In(1) != paramsType {
 		return nil, errgo.Newf("second argument is %s, need %s", t.In(1), paramsType)
 	}
-	pt, err := getRequestType(preprocessType{reflectType: t.In(2), purpose: purposeUnmarshal})
+	pt, err := getRequestType(t.In(2))
 	if err != nil {
 		return nil, errgo.Notef(err, "third argument cannot be used for Unmarshal")
 	}

--- a/handler_test.go
+++ b/handler_test.go
@@ -55,6 +55,7 @@ var handleTests = []struct {
 		}
 	},
 	req: &http.Request{
+		Header: http.Header{"Content-Type": {"application/json"}},
 		Form: url.Values{
 			"c": {"43"},
 		},

--- a/marshal.go
+++ b/marshal.go
@@ -21,30 +21,30 @@ import (
 //
 // See: Unmarshal for more details.
 //
-// For fields with a "path" item in the structural tag, the request uri must
+// For fields with a "path" item in the structural tag, the base uri must
 // contain a placeholder with its name.
 // Example:
 // For
 //    type Test struct {
 //	    username string `httprequest:"user,path"`
 //    }
-// ...the request url must contain a "::user::" placeholder:
+// ...the request url must contain a ":user" placeholder:
 //    http://localhost:8081/:user/files
 //
 // If a type does not implement the encoding.TextMarshaler fmt.Sprint will
 // be used to marshal its value.
-func Marshal(baseURL, method string, input interface{}) (*http.Request, error) {
-	xv := reflect.ValueOf(input)
-	pt, err := getRequestType(preprocessType{reflectType: xv.Type(), purpose: purposeMarshal})
+func Marshal(baseURL, method string, i interface{}) (*http.Request, error) {
+	input := reflect.ValueOf(i)
+	pt, err := getRequestType(preprocessType{reflectType: input.Type(), purpose: purposeMarshal})
 	if err != nil {
-		return nil, errgo.WithCausef(err, ErrBadUnmarshalType, "bad type %s", xv.Type())
+		return nil, errgo.WithCausef(err, ErrBadUnmarshalType, "bad type %s", input.Type())
 	}
 	req, err := http.NewRequest(method, baseURL, bytes.NewBuffer(nil))
 	if err != nil {
 		return nil, errgo.Mask(err)
 	}
 	p := &Params{req, httprouter.Params{}}
-	if err := marshal(p, xv, pt); err != nil {
+	if err := marshal(p, input, pt); err != nil {
 		return nil, errgo.Mask(err, errgo.Is(ErrUnmarshal))
 	}
 	return p.Request, nil

--- a/marshal.go
+++ b/marshal.go
@@ -26,6 +26,11 @@ import (
 //  baseURL will be filled out from "path"-tagged fields in x to form the
 //  URL path in the returned request.  These are specified as for httprouter.
 //
+//  If a field in baseURL is a suffix of the form "*var" (a trailing wildcard element
+//  that holds the rest of the path), the marshaled string must begin with a "/".
+//  This matches the httprouter convention that it always returns such fields
+//  with a "/" prefix.
+//
 //  If a field is of type string or []string, the value of the field will
 //  be used directly; otherwise if implements encoding.TextMarshaler, that
 //  will be used to marshal the field, otherwise fmt.Sprint will be used.

--- a/marshal.go
+++ b/marshal.go
@@ -1,0 +1,262 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package httprequest
+
+import (
+	"bytes"
+	"encoding"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"reflect"
+
+	"github.com/julienschmidt/httprouter"
+	"gopkg.in/errgo.v1"
+)
+
+// Marshal takes the input structure and creates an http request.
+//
+// See: Unmarshal for more details.
+//
+// For fields with a "path" item in the structural tag, the request uri must
+// contain a placeholder with its name.
+// Example:
+// For
+//    type Test struct {
+//	    username string `httprequest:"user,path"`
+//    }
+// ...the request url must contain a "::user::" placeholder:
+//    http://localhost:8081/:user/files
+//
+// If a type does not implement the encoding.TextMarshaler fmt.Sprint will
+// be used to marshal its value.
+func Marshal(baseURL, method string, input interface{}) (*http.Request, error) {
+	xv := reflect.ValueOf(input)
+	pt, err := getRequestType(preprocessType{reflectType: xv.Type(), purpose: purposeMarshal})
+	if err != nil {
+		return nil, errgo.WithCausef(err, ErrBadUnmarshalType, "bad type %s", xv.Type())
+	}
+	req, err := http.NewRequest(method, baseURL, bytes.NewBuffer(nil))
+	if err != nil {
+		return nil, errgo.Mask(err)
+	}
+	p := &Params{req, httprouter.Params{}}
+	if err := marshal(p, xv, pt); err != nil {
+		return nil, errgo.Mask(err, errgo.Is(ErrUnmarshal))
+	}
+	return p.Request, nil
+}
+
+// marshal is the internal version of Marshal.
+func marshal(p *Params, xv reflect.Value, pt *requestType) error {
+	if xv.Kind() == reflect.Ptr {
+		xv = xv.Elem()
+	}
+	for _, f := range pt.fields {
+		fv := xv.FieldByIndex(f.index)
+
+		// TODO store the field name in the field so
+		// that we can produce a nice error message.
+		if err := f.marshal(fv, p, f.makeResult); err != nil {
+			return errgo.WithCausef(err, ErrUnmarshal, "cannot marshal field")
+		}
+	}
+
+	urlString := p.URL.Path
+	var pathBuffer bytes.Buffer
+	paramsByName := make(map[string]string)
+	for _, param := range p.PathVar {
+		paramsByName[param.Key] = param.Value
+	}
+
+	offset := 0
+	hasParams := false
+	for i := 0; i < len(urlString); i++ {
+		c := urlString[i]
+		if c != ':' {
+			continue
+		}
+		hasParams = true
+
+		end := i + 1
+		for end < len(urlString) && urlString[end] != ':' && urlString[end] != '/' {
+			end++
+		}
+
+		if end-i < 2 {
+			return errgo.New("request wildcards must be named with a non-empty name")
+		}
+		if i > 0 {
+			pathBuffer.WriteString(urlString[offset:i])
+		}
+
+		wildcard := urlString[i+1 : end]
+		paramValue, ok := paramsByName[wildcard]
+		if !ok {
+			return errgo.Newf("missing value for path parameter %q", wildcard)
+		}
+		pathBuffer.WriteString(paramValue)
+		offset = end
+	}
+	if !hasParams {
+		pathBuffer.WriteString(urlString)
+	}
+
+	p.URL.Path = pathBuffer.String()
+
+	p.URL.RawQuery = p.Form.Encode()
+
+	return nil
+}
+
+// getMarshaler returns a marshaler function suitable for marshaling
+// a field with the given tag into and http request.
+func getMarshaler(tag tag, t reflect.Type) (marshaler, error) {
+	switch {
+	case tag.source == sourceNone:
+		return marshalNop, nil
+	case tag.source == sourceBody:
+		return marshalBody, nil
+	case t == reflect.TypeOf([]string(nil)):
+		if tag.source != sourceForm {
+			return nil, errgo.New("invalid target type []string for path parameter")
+		}
+		return marshalAllField(tag.name), nil
+	case t == reflect.TypeOf(""):
+		return marshalString(tag), nil
+	case implementsTextMarshaler(t):
+		return marshalWithMarshalText(t, tag), nil
+	default:
+		return marshalWithSprint(tag), nil
+	}
+}
+
+// marshalNop does nothing with the value.
+func marshalNop(v reflect.Value, p *Params, makeResult resultMaker) error {
+	return nil
+}
+
+// mashalBody marshals the specified value into the body of the http request.
+func marshalBody(v reflect.Value, p *Params, makeResult resultMaker) error {
+	// TODO allow body types that aren't necessarily JSON.
+	bodyValue := makeResult(v)
+	if bodyValue == emptyValue {
+		return nil
+	}
+
+	if p.Method != "POST" && p.Method != "PUT" {
+		return errgo.Newf("trying to marshal to body of a request with method %q", p.Method)
+	}
+
+	data, err := json.Marshal(bodyValue.Interface())
+	if err != nil {
+		return errgo.Notef(err, "cannot marshal request body")
+	}
+	p.Body = ioutil.NopCloser(bytes.NewBuffer(data))
+	return nil
+}
+
+// marshalAllField marshals a []string slice into form fields.
+func marshalAllField(name string) marshaler {
+	return func(v reflect.Value, p *Params, makeResult resultMaker) error {
+		value := makeResult(v)
+		if value == emptyValue {
+			return nil
+		}
+		values := value.Interface().([]string)
+		if p.Form == nil {
+			p.Form = url.Values{}
+		}
+		for _, value := range values {
+			p.Form.Add(name, value)
+		}
+		return nil
+	}
+}
+
+// marshalString marshals s string field.
+func marshalString(tag tag) marshaler {
+	formSet := formSetters[tag.source]
+	if formSet == nil {
+		panic("unexpected source")
+	}
+	return func(v reflect.Value, p *Params, makeResult resultMaker) error {
+		value := makeResult(v)
+		if value == emptyValue {
+			return nil
+		}
+		formSet(tag.name, value.String(), p)
+		return nil
+	}
+}
+
+var textMarshalerType = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
+
+func implementsTextMarshaler(t reflect.Type) bool {
+	// Use the pointer type, because a pointer
+	// type will implement a superset of the methods
+	// of a non-pointer type.
+	return reflect.PtrTo(t).Implements(textMarshalerType)
+}
+
+// marshalWithMarshalText returns a marshaler
+// that marshals the given type from the given tag
+// using its MarshalText method.
+func marshalWithMarshalText(t reflect.Type, tag tag) marshaler {
+	formSet := formSetters[tag.source]
+	if formSet == nil {
+		panic("unexpected source")
+	}
+	return func(v reflect.Value, p *Params, makeResult resultMaker) error {
+		value := makeResult(v)
+		if value == emptyValue {
+			return nil
+		}
+		m := value.Addr().Interface().(encoding.TextMarshaler)
+		data, err := m.MarshalText()
+		if err != nil {
+			return errgo.Mask(err)
+		}
+		formSet(tag.name, string(data), p)
+
+		return nil
+	}
+}
+
+// marshalWithScan returns an marshaler
+// that unmarshals the given tag using fmt.Sprint.
+func marshalWithSprint(tag tag) marshaler {
+	formSet := formSetters[tag.source]
+	if formSet == nil {
+		panic("unexpected source")
+	}
+	return func(v reflect.Value, p *Params, makeResult resultMaker) error {
+		value := makeResult(v)
+		if value == emptyValue {
+			return nil
+		}
+		valueString := fmt.Sprint(value.Interface())
+
+		formSet(tag.name, valueString, p)
+
+		return nil
+	}
+}
+
+// formSetters maps from source to a function that
+// sets the value for a given key.
+var formSetters = []func(string, string, *Params){
+	sourceForm: func(name, value string, p *Params) {
+		if p.Form == nil {
+			p.Form = url.Values{}
+		}
+		p.Form.Add(name, value)
+	},
+	sourcePath: func(name, value string, p *Params) {
+		p.PathVar = append(p.PathVar, httprouter.Param{Key: name, Value: value})
+	},
+	sourceBody: nil,
+}

--- a/marshal.go
+++ b/marshal.go
@@ -32,14 +32,15 @@ import (
 //
 //  For example, this code:
 //
-//      type UserDetails struct {
-//          Age int
-//      }
-//       type Test struct {
-//          Username string `httprequest:"user,path"`
-//          ContextId int64 `httprequest:"context,form"`
-//          Details UserDetails `httprequest:",body"`
-//      }
+//  type UserDetails struct {
+//      Age int
+//  }
+//
+//  type Test struct {
+//      Username string `httprequest:"user,path"`
+//      ContextId int64 `httprequest:"context,form"`
+//      Details UserDetails `httprequest:",body"`
+//  }
 //  req, err := Marshal("GET", "http://example.com/users/:user/details", &Test{
 //      Username: "bob",
 //      ContextId: 1234,
@@ -194,7 +195,7 @@ func marshalNop(v reflect.Value, p *Params) error {
 func marshalBody(v reflect.Value, p *Params) error {
 	// TODO allow body types that aren't necessarily JSON.
 	if p.Method == "GET" || p.Method == "HEAD" {
-		return errgo.Newf("trying to marshal to body of a request with method %q", p.Method)
+		return errgo.Newf("cannot specify a body with %s method", p.Method)
 	}
 
 	data, err := json.Marshal(v.Addr().Interface())

--- a/marshal.go
+++ b/marshal.go
@@ -31,8 +31,8 @@ import (
 // ...the request url must contain a ":user" placeholder:
 //    http://localhost:8081/:user/files
 //
-// If a type does not implement the encoding.TextMarshaler fmt.Sprint will
-// be used to marshal its value.
+// If url path contains a placeholder, but the input struct does not marshal
+// to that placeholder, an error is raised.
 func Marshal(baseURL, method string, x interface{}) (*http.Request, error) {
 	xv := reflect.ValueOf(x)
 	pt, err := getRequestType(xv.Type())
@@ -43,7 +43,11 @@ func Marshal(baseURL, method string, x interface{}) (*http.Request, error) {
 	if err != nil {
 		return nil, errgo.Mask(err)
 	}
-	p := &Params{req, httprouter.Params{}}
+
+	p := &Params{
+		Request: req,
+	}
+
 	if err := marshal(p, xv, pt); err != nil {
 		return nil, errgo.Mask(err, errgo.Is(ErrUnmarshal))
 	}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -209,7 +209,7 @@ var marshalTests = []struct {
 	}{
 		F1: "hello test",
 	},
-	expectError: "cannot marshal field: trying to marshal to body of a request with method \"GET\"",
+	expectError: "cannot marshal field: cannot specify a body with GET method",
 }, {
 	about:     "marshal to nil value to body",
 	urlString: "http://localhost:8081/u",

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1,0 +1,355 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package httprequest_test
+
+import (
+	"io/ioutil"
+
+	"github.com/juju/httprequest"
+
+	gc "gopkg.in/check.v1"
+	"gopkg.in/errgo.v1"
+)
+
+type marshalSuite struct{}
+
+var _ = gc.Suite(&marshalSuite{})
+
+var marshalTests = []struct {
+	about           string
+	urlString       string
+	method          string
+	val             func() interface{}
+	expectURLString string
+	expectBody      string
+	expectError     string
+}{{
+	about:     "struct with simple fields",
+	urlString: "http://localhost:8081/:F1",
+	val: func() interface{} {
+		t := struct {
+			F1 int    `httprequest:",path"`
+			F2 string `httprequest:",form"`
+		}{
+			F1: 99,
+			F2: "some text",
+		}
+		return &t
+	},
+	expectURLString: "http://localhost:8081/99?F2=some+text",
+}, {
+	about:     "struct with renamed fields",
+	urlString: "http://localhost:8081/:name",
+	val: func() interface{} {
+		t := struct {
+			F1 string `httprequest:"name,path"`
+			F2 int    `httprequest:"age,form"`
+		}{
+			F1: "some random user",
+			F2: 42,
+		}
+		return &t
+	},
+	expectURLString: "http://localhost:8081/some%20random%20user?age=42",
+}, {
+	about:     "fields without httprequest tags are ignored",
+	urlString: "http://localhost:8081/:name",
+	val: func() interface{} {
+		t := struct {
+			F1 string `httprequest:"name,path"`
+			F2 int    `httprequest:"age,form"`
+			F3 string
+		}{
+			F1: "some random user",
+			F2: 42,
+			F3: "some more random text",
+		}
+		return &t
+	},
+	expectURLString: "http://localhost:8081/some%20random%20user?age=42",
+}, {
+	about:     "pointer fields are correctly handled",
+	urlString: "http://localhost:8081/:name",
+	val: func() interface{} {
+		t := struct {
+			F1 *string `httprequest:"name,path"`
+			F2 *string `httprequest:"age,form"`
+			F3 *string `httprequest:"address,form"`
+		}{
+			F1: newString("some random user"),
+			F2: newString("42"),
+		}
+		return &t
+	},
+	expectURLString: "http://localhost:8081/some%20random%20user?age=42",
+}, {
+	about:     "MarshalText called on TextMarhsalers",
+	urlString: "http://localhost:8081/:param1/:param2",
+	val: func() interface{} {
+		v := struct {
+			F1 testMarshaler  `httprequest:"param1,path"`
+			F2 *testMarshaler `httprequest:"param2,path"`
+			F3 testMarshaler  `httprequest:"param3,form"`
+			F4 *testMarshaler `httprequest:"param4,form"`
+		}{
+			F1: "test1",
+			F2: (*testMarshaler)(newString("test2")),
+			F3: "test3",
+			F4: (*testMarshaler)(newString("test4")),
+		}
+		return &v
+	},
+	expectURLString: "http://localhost:8081/test_test1/test_test2?param3=test_test3&param4=test_test4",
+}, {
+	about:     "MarshalText called on TextMarhsalers",
+	urlString: "http://localhost:8081/user/:name:surname",
+	val: func() interface{} {
+		v := struct {
+			F1 testMarshaler  `httprequest:"name,path"`
+			F2 *testMarshaler `httprequest:"surname,path"`
+		}{
+			F1: "name",
+			F2: (*testMarshaler)(newString("surname")),
+		}
+		return &v
+	},
+	expectURLString: "http://localhost:8081/user/test_nametest_surname",
+}, {
+	about:     "MarshalText not called on values that do not implement TextMarshaler",
+	urlString: "http://localhost:8081/user/:name:surname",
+	val: func() interface{} {
+		v := struct {
+			F1 notTextMarshaler  `httprequest:"name,path"`
+			F2 *notTextMarshaler `httprequest:"surname,path"`
+		}{
+			F1: "name",
+			F2: (*notTextMarshaler)(newString("surname")),
+		}
+		return &v
+	},
+	expectURLString: "http://localhost:8081/user/namesurname",
+}, {
+	about:     "MarshalText returns an error",
+	urlString: "http://localhost:8081/user/:name:surname",
+	val: func() interface{} {
+		v := struct {
+			F1 testMarshaler  `httprequest:"name,path"`
+			F2 *testMarshaler `httprequest:"surname,path"`
+		}{
+			F1: "",
+			F2: (*testMarshaler)(newString("surname")),
+		}
+		return &v
+	},
+	expectError: "cannot marshal field: empty string",
+}, {
+	about:     "[]string field form value",
+	urlString: "http://localhost:8081/user",
+	val: func() interface{} {
+		v := struct {
+			F1 []string `httprequest:"users,form"`
+		}{
+			F1: []string{"user1", "user2", "user3"},
+		}
+		return &v
+	},
+	expectURLString: "http://localhost:8081/user?users=user1&users=user2&users=user3",
+}, {
+	about:     "nil []string field form value",
+	urlString: "http://localhost:8081/user",
+	val: func() interface{} {
+		v := struct {
+			F1 *[]string `httprequest:"users,form"`
+		}{
+			F1: nil,
+		}
+		return &v
+	},
+	expectURLString: "http://localhost:8081/user",
+}, {
+	about:     "[]string field fails to marshal to path",
+	urlString: "http://localhost:8081/user/:users",
+	val: func() interface{} {
+		v := struct {
+			F1 []string `httprequest:"users,path"`
+		}{
+			F1: []string{"user1", "user2", "user3"},
+		}
+		return &v
+	},
+	expectError: ".*invalid target type.*",
+}, {
+	about:     "more than one field with body tag",
+	urlString: "http://localhost:8081/user",
+	method:    "POST",
+	val: func() interface{} {
+		v := struct {
+			F1 string `httprequest:"user,body"`
+			F2 int    `httprequest:"age,body"`
+		}{
+			F1: "test user",
+			F2: 42,
+		}
+		return &v
+	},
+	expectError: ".*more than one body field specified",
+}, {
+	about:     "required path parameter, but not specified",
+	urlString: "http://localhost:8081/u/:username",
+	method:    "POST",
+	val: func() interface{} {
+		v := struct {
+			F1 string `httprequest:"user,body"`
+		}{
+			F1: "test user",
+		}
+		return &v
+	},
+	expectError: "missing value for path parameter \"username\"",
+}, {
+	about:     "marshal to body",
+	urlString: "http://localhost:8081/u",
+	method:    "POST",
+	val: func() interface{} {
+		type embedded struct {
+			F1 string `json:"name"`
+			F2 int    `json:"age"`
+			F3 string `json:"address"`
+		}
+		v1 := embedded{
+			F1: "test user",
+			F2: 42,
+			F3: "test address",
+		}
+		v := struct {
+			F1 embedded `httprequest:"info,body"`
+		}{
+			F1: v1,
+		}
+		return &v
+	},
+	expectBody: "{\"name\":\"test user\",\"age\":42,\"address\":\"test address\"}",
+}, {
+	about:     "empty path wildcard",
+	urlString: "http://localhost:8081/u/:",
+	method:    "POST",
+	val: func() interface{} {
+		v := struct {
+			F1 string `httprequest:"user,body"`
+		}{
+			F1: "test user",
+		}
+		return &v
+	},
+	expectError: "request wildcards must be named with a non-empty name",
+}, {
+	about:     "nil field to form",
+	urlString: "http://localhost:8081/u",
+	val: func() interface{} {
+		v := struct {
+			F1 *string `httprequest:"user,form"`
+		}{}
+		return &v
+	},
+	expectURLString: "http://localhost:8081/u",
+}, {
+	about:     "nil field to path",
+	urlString: "http://localhost:8081/u",
+	val: func() interface{} {
+		v := struct {
+			F1 *string `httprequest:"user,path"`
+		}{}
+		return &v
+	},
+	expectURLString: "http://localhost:8081/u",
+}, {
+	about:     "marshal to body of a GET request",
+	urlString: "http://localhost:8081/u",
+	val: func() interface{} {
+		v := struct {
+			F1 string `httprequest:"user,body"`
+		}{
+			F1: "hello test",
+		}
+		return &v
+	},
+	expectError: "cannot marshal field: trying to marshal to body of a request with method \"GET\"",
+}, {
+	about:     "marshal to nil value to body",
+	urlString: "http://localhost:8081/u",
+	val: func() interface{} {
+		v := struct {
+			F1 *string `httprequest:"user,body"`
+		}{
+			F1: nil,
+		}
+		return &v
+	},
+	expectBody: "",
+}, {
+	about:     "nil TextMarhsaler",
+	urlString: "http://localhost:8081/u",
+	val: func() interface{} {
+		v := struct {
+			F1 *testMarshaler `httprequest:"surname,form"`
+		}{
+			F1: (*testMarshaler)(nil),
+		}
+		return &v
+	},
+	expectURLString: "http://localhost:8081/u",
+}, {
+	about:     "marshal nil with Sprint",
+	urlString: "http://localhost:8081/u",
+	val: func() interface{} {
+		v := struct {
+			F1 *int `httprequest:"surname,form"`
+		}{
+			F1: (*int)(nil),
+		}
+		return &v
+	},
+	expectURLString: "http://localhost:8081/u",
+},
+}
+
+func (*marshalSuite) TestMarshal(c *gc.C) {
+	for i, test := range marshalTests {
+		c.Logf("%d: %s", i, test.about)
+		method := "GET"
+		if test.method != "" {
+			method = test.method
+		}
+		req, err := httprequest.Marshal(test.urlString, method, test.val())
+		if test.expectError != "" {
+			c.Assert(err, gc.ErrorMatches, test.expectError)
+			continue
+		}
+		c.Assert(err, gc.IsNil)
+		if test.expectURLString != "" {
+			c.Assert(req.URL.String(), gc.DeepEquals, test.expectURLString)
+		}
+		//if test.expectBody != "" {
+		data, err := ioutil.ReadAll(req.Body)
+		c.Assert(err, gc.IsNil)
+		c.Assert(string(data), gc.DeepEquals, test.expectBody)
+		//}
+	}
+}
+
+type testMarshaler string
+
+func (t *testMarshaler) MarshalText() ([]byte, error) {
+	if len(*t) == 0 {
+		return nil, errgo.New("empty string")
+	}
+	return []byte("test_" + *t), nil
+}
+
+type notTextMarshaler string
+
+// MarshalText does *not* implement encoding.TextMarshaler
+func (t *notTextMarshaler) MarshalText() {
+	panic("unexpected call")
+}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -16,326 +16,254 @@ type marshalSuite struct{}
 
 var _ = gc.Suite(&marshalSuite{})
 
+type embedded struct {
+	F1 string  `json:"name"`
+	F2 int     `json:"age"`
+	F3 *string `json:"address"`
+}
+
 var marshalTests = []struct {
 	about           string
 	urlString       string
 	method          string
-	val             func() interface{}
+	val             interface{}
 	expectURLString string
-	expectBody      string
+	expectBody      *string
 	expectError     string
 }{{
 	about:     "struct with simple fields",
 	urlString: "http://localhost:8081/:F1",
-	val: func() interface{} {
-		t := struct {
-			F1 int    `httprequest:",path"`
-			F2 string `httprequest:",form"`
-		}{
-			F1: 99,
-			F2: "some text",
-		}
-		return &t
+	val: &struct {
+		F1 int    `httprequest:",path"`
+		F2 string `httprequest:",form"`
+	}{
+		F1: 99,
+		F2: "some text",
 	},
 	expectURLString: "http://localhost:8081/99?F2=some+text",
 }, {
 	about:     "struct with renamed fields",
 	urlString: "http://localhost:8081/:name",
-	val: func() interface{} {
-		t := struct {
-			F1 string `httprequest:"name,path"`
-			F2 int    `httprequest:"age,form"`
-		}{
-			F1: "some random user",
-			F2: 42,
-		}
-		return &t
+	val: &struct {
+		F1 string `httprequest:"name,path"`
+		F2 int    `httprequest:"age,form"`
+	}{
+		F1: "some random user",
+		F2: 42,
 	},
 	expectURLString: "http://localhost:8081/some%20random%20user?age=42",
 }, {
 	about:     "fields without httprequest tags are ignored",
 	urlString: "http://localhost:8081/:name",
-	val: func() interface{} {
-		t := struct {
-			F1 string `httprequest:"name,path"`
-			F2 int    `httprequest:"age,form"`
-			F3 string
-		}{
-			F1: "some random user",
-			F2: 42,
-			F3: "some more random text",
-		}
-		return &t
+	val: &struct {
+		F1 string `httprequest:"name,path"`
+		F2 int    `httprequest:"age,form"`
+		F3 string
+	}{
+		F1: "some random user",
+		F2: 42,
+		F3: "some more random text",
 	},
 	expectURLString: "http://localhost:8081/some%20random%20user?age=42",
 }, {
 	about:     "pointer fields are correctly handled",
 	urlString: "http://localhost:8081/:name",
-	val: func() interface{} {
-		t := struct {
-			F1 *string `httprequest:"name,path"`
-			F2 *string `httprequest:"age,form"`
-			F3 *string `httprequest:"address,form"`
-		}{
-			F1: newString("some random user"),
-			F2: newString("42"),
-		}
-		return &t
+	val: &struct {
+		F1 *string `httprequest:"name,path"`
+		F2 *string `httprequest:"age,form"`
+		F3 *string `httprequest:"address,form"`
+	}{
+		F1: newString("some random user"),
+		F2: newString("42"),
 	},
 	expectURLString: "http://localhost:8081/some%20random%20user?age=42",
 }, {
-	about:     "MarshalText called on TextMarhsalers",
+	about:     "MarshalText called on TextMarshalers",
 	urlString: "http://localhost:8081/:param1/:param2",
-	val: func() interface{} {
-		v := struct {
-			F1 testMarshaler  `httprequest:"param1,path"`
-			F2 *testMarshaler `httprequest:"param2,path"`
-			F3 testMarshaler  `httprequest:"param3,form"`
-			F4 *testMarshaler `httprequest:"param4,form"`
-		}{
-			F1: "test1",
-			F2: (*testMarshaler)(newString("test2")),
-			F3: "test3",
-			F4: (*testMarshaler)(newString("test4")),
-		}
-		return &v
+	val: &struct {
+		F1 testMarshaler  `httprequest:"param1,path"`
+		F2 *testMarshaler `httprequest:"param2,path"`
+		F3 testMarshaler  `httprequest:"param3,form"`
+		F4 *testMarshaler `httprequest:"param4,form"`
+	}{
+		F1: "test1",
+		F2: (*testMarshaler)(newString("test2")),
+		F3: "test3",
+		F4: (*testMarshaler)(newString("test4")),
 	},
 	expectURLString: "http://localhost:8081/test_test1/test_test2?param3=test_test3&param4=test_test4",
 }, {
-	about:     "MarshalText called on TextMarhsalers",
-	urlString: "http://localhost:8081/user/:name:surname",
-	val: func() interface{} {
-		v := struct {
-			F1 testMarshaler  `httprequest:"name,path"`
-			F2 *testMarshaler `httprequest:"surname,path"`
-		}{
-			F1: "name",
-			F2: (*testMarshaler)(newString("surname")),
-		}
-		return &v
-	},
-	expectURLString: "http://localhost:8081/user/test_nametest_surname",
-}, {
 	about:     "MarshalText not called on values that do not implement TextMarshaler",
-	urlString: "http://localhost:8081/user/:name:surname",
-	val: func() interface{} {
-		v := struct {
-			F1 notTextMarshaler  `httprequest:"name,path"`
-			F2 *notTextMarshaler `httprequest:"surname,path"`
-		}{
-			F1: "name",
-			F2: (*notTextMarshaler)(newString("surname")),
-		}
-		return &v
+	urlString: "http://localhost:8081/user/:name/:surname",
+	val: &struct {
+		F1 notTextMarshaler  `httprequest:"name,path"`
+		F2 *notTextMarshaler `httprequest:"surname,path"`
+	}{
+		F1: "name",
+		F2: (*notTextMarshaler)(newString("surname")),
 	},
-	expectURLString: "http://localhost:8081/user/namesurname",
+	expectURLString: "http://localhost:8081/user/name/surname",
 }, {
 	about:     "MarshalText returns an error",
-	urlString: "http://localhost:8081/user/:name:surname",
-	val: func() interface{} {
-		v := struct {
-			F1 testMarshaler  `httprequest:"name,path"`
-			F2 *testMarshaler `httprequest:"surname,path"`
-		}{
-			F1: "",
-			F2: (*testMarshaler)(newString("surname")),
-		}
-		return &v
+	urlString: "http://localhost:8081/user/:name/:surname",
+	val: &struct {
+		F1 testMarshaler  `httprequest:"name,path"`
+		F2 *testMarshaler `httprequest:"surname,path"`
+	}{
+		F1: "",
+		F2: (*testMarshaler)(newString("surname")),
 	},
 	expectError: "cannot marshal field: empty string",
 }, {
 	about:     "[]string field form value",
 	urlString: "http://localhost:8081/user",
-	val: func() interface{} {
-		v := struct {
-			F1 []string `httprequest:"users,form"`
-		}{
-			F1: []string{"user1", "user2", "user3"},
-		}
-		return &v
+	val: &struct {
+		F1 []string `httprequest:"users,form"`
+	}{
+		F1: []string{"user1", "user2", "user3"},
 	},
 	expectURLString: "http://localhost:8081/user?users=user1&users=user2&users=user3",
 }, {
 	about:     "nil []string field form value",
 	urlString: "http://localhost:8081/user",
-	val: func() interface{} {
-		v := struct {
-			F1 *[]string `httprequest:"users,form"`
-		}{
-			F1: nil,
-		}
-		return &v
+	val: &struct {
+		F1 *[]string `httprequest:"users,form"`
+	}{
+		F1: nil,
 	},
 	expectURLString: "http://localhost:8081/user",
 }, {
 	about:     "[]string field fails to marshal to path",
 	urlString: "http://localhost:8081/user/:users",
-	val: func() interface{} {
-		v := struct {
-			F1 []string `httprequest:"users,path"`
-		}{
-			F1: []string{"user1", "user2", "user3"},
-		}
-		return &v
+	val: &struct {
+		F1 []string `httprequest:"users,path"`
+	}{
+		F1: []string{"user1", "user2", "user3"},
 	},
 	expectError: ".*invalid target type.*",
 }, {
 	about:     "more than one field with body tag",
 	urlString: "http://localhost:8081/user",
 	method:    "POST",
-	val: func() interface{} {
-		v := struct {
-			F1 string `httprequest:"user,body"`
-			F2 int    `httprequest:"age,body"`
-		}{
-			F1: "test user",
-			F2: 42,
-		}
-		return &v
+	val: &struct {
+		F1 string `httprequest:"user,body"`
+		F2 int    `httprequest:"age,body"`
+	}{
+		F1: "test user",
+		F2: 42,
 	},
 	expectError: ".*more than one body field specified",
 }, {
 	about:     "required path parameter, but not specified",
 	urlString: "http://localhost:8081/u/:username",
 	method:    "POST",
-	val: func() interface{} {
-		v := struct {
-			F1 string `httprequest:"user,body"`
-		}{
-			F1: "test user",
-		}
-		return &v
+	val: &struct {
+		F1 string `httprequest:"user,body"`
+	}{
+		F1: "test user",
 	},
 	expectError: "missing value for path parameter \"username\"",
 }, {
 	about:     "marshal to body",
 	urlString: "http://localhost:8081/u",
 	method:    "POST",
-	val: func() interface{} {
-		type embedded struct {
-			F1 string `json:"name"`
-			F2 int    `json:"age"`
-			F3 string `json:"address"`
-		}
-		v1 := embedded{
+	val: &struct {
+		F1 embedded `httprequest:"info,body"`
+	}{
+		F1: embedded{
 			F1: "test user",
 			F2: 42,
-			F3: "test address",
-		}
-		v := struct {
-			F1 embedded `httprequest:"info,body"`
-		}{
-			F1: v1,
-		}
-		return &v
+			F3: newString("test address"),
+		},
 	},
-	expectBody: "{\"name\":\"test user\",\"age\":42,\"address\":\"test address\"}",
+	expectBody: newString("{\"name\":\"test user\",\"age\":42,\"address\":\"test address\"}"),
 }, {
 	about:     "empty path wildcard",
 	urlString: "http://localhost:8081/u/:",
 	method:    "POST",
-	val: func() interface{} {
-		v := struct {
-			F1 string `httprequest:"user,body"`
-		}{
-			F1: "test user",
-		}
-		return &v
+	val: &struct {
+		F1 string `httprequest:"user,body"`
+	}{
+		F1: "test user",
 	},
-	expectError: "request wildcards must be named with a non-empty name",
+	expectError: "empty path parameter",
 }, {
 	about:     "nil field to form",
 	urlString: "http://localhost:8081/u",
-	val: func() interface{} {
-		v := struct {
-			F1 *string `httprequest:"user,form"`
-		}{}
-		return &v
-	},
+	val: &struct {
+		F1 *string `httprequest:"user,form"`
+	}{},
 	expectURLString: "http://localhost:8081/u",
 }, {
 	about:     "nil field to path",
 	urlString: "http://localhost:8081/u",
-	val: func() interface{} {
-		v := struct {
-			F1 *string `httprequest:"user,path"`
-		}{}
-		return &v
-	},
+	val: &struct {
+		F1 *string `httprequest:"user,path"`
+	}{},
 	expectURLString: "http://localhost:8081/u",
 }, {
 	about:     "marshal to body of a GET request",
 	urlString: "http://localhost:8081/u",
-	val: func() interface{} {
-		v := struct {
-			F1 string `httprequest:"user,body"`
-		}{
-			F1: "hello test",
-		}
-		return &v
+	val: &struct {
+		F1 string `httprequest:"user,body"`
+	}{
+		F1: "hello test",
 	},
 	expectError: "cannot marshal field: trying to marshal to body of a request with method \"GET\"",
 }, {
 	about:     "marshal to nil value to body",
 	urlString: "http://localhost:8081/u",
-	val: func() interface{} {
-		v := struct {
-			F1 *string `httprequest:"user,body"`
-		}{
-			F1: nil,
-		}
-		return &v
+	val: &struct {
+		F1 *string `httprequest:"user,body"`
+	}{
+		F1: nil,
 	},
-	expectBody: "",
+	expectBody: newString(""),
 }, {
-	about:     "nil TextMarhsaler",
+	about:     "nil TextMarshaler",
 	urlString: "http://localhost:8081/u",
-	val: func() interface{} {
-		v := struct {
-			F1 *testMarshaler `httprequest:"surname,form"`
-		}{
-			F1: (*testMarshaler)(nil),
-		}
-		return &v
+	val: &struct {
+		F1 *testMarshaler `httprequest:"surname,form"`
+	}{
+		F1: (*testMarshaler)(nil),
 	},
 	expectURLString: "http://localhost:8081/u",
 }, {
 	about:     "marshal nil with Sprint",
 	urlString: "http://localhost:8081/u",
-	val: func() interface{} {
-		v := struct {
-			F1 *int `httprequest:"surname,form"`
-		}{
-			F1: (*int)(nil),
-		}
-		return &v
+	val: &struct {
+		F1 *int `httprequest:"surname,form"`
+	}{
+		F1: (*int)(nil),
 	},
 	expectURLString: "http://localhost:8081/u",
 }, {
 	about:     "marshal to path with * placeholder",
 	urlString: "http://localhost:8081/u/*name",
-	val: func() interface{} {
-		v := struct {
-			F1 string `httprequest:"name,path"`
-		}{
-			F1: "test",
-		}
-		return &v
+	val: &struct {
+		F1 string `httprequest:"name,path"`
+	}{
+		F1: "/test",
 	},
 	expectURLString: "http://localhost:8081/u/test",
 }, {
 	about:     "* placeholder allowed only at the ned",
 	urlString: "http://localhost:8081/u/*name/document",
-	val: func() interface{} {
-		v := struct {
-			F1 string `httprequest:"name,path"`
-		}{
-			F1: "test",
-		}
-		return &v
+	val: &struct {
+		F1 string `httprequest:"name,path"`
+	}{
+		F1: "test",
 	},
-	expectError: `placeholders starting with \* are only allowed at the end`,
+	expectError: "star path parameter is not at end of path",
 },
+}
+
+func getStruct() interface{} {
+	return &struct {
+		F1 string
+	}{
+		F1: "hello",
+	}
 }
 
 func (*marshalSuite) TestMarshal(c *gc.C) {
@@ -345,7 +273,7 @@ func (*marshalSuite) TestMarshal(c *gc.C) {
 		if test.method != "" {
 			method = test.method
 		}
-		req, err := httprequest.Marshal(test.urlString, method, test.val())
+		req, err := httprequest.Marshal(test.urlString, method, test.val)
 		if test.expectError != "" {
 			c.Assert(err, gc.ErrorMatches, test.expectError)
 			continue
@@ -354,11 +282,14 @@ func (*marshalSuite) TestMarshal(c *gc.C) {
 		if test.expectURLString != "" {
 			c.Assert(req.URL.String(), gc.DeepEquals, test.expectURLString)
 		}
-		//if test.expectBody != "" {
-		data, err := ioutil.ReadAll(req.Body)
-		c.Assert(err, gc.IsNil)
-		c.Assert(string(data), gc.DeepEquals, test.expectBody)
-		//}
+		if test.expectBody != nil {
+			data, err := ioutil.ReadAll(req.Body)
+			c.Assert(err, gc.IsNil)
+			if *test.expectBody != "" {
+				c.Assert(req.Header.Get("Content-Type"), gc.Equals, "application/json")
+			}
+			c.Assert(string(data), gc.DeepEquals, *test.expectBody)
+		}
 	}
 }
 

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -311,6 +311,30 @@ var marshalTests = []struct {
 		return &v
 	},
 	expectURLString: "http://localhost:8081/u",
+}, {
+	about:     "marshal to path with * placeholder",
+	urlString: "http://localhost:8081/u/*name",
+	val: func() interface{} {
+		v := struct {
+			F1 string `httprequest:"name,path"`
+		}{
+			F1: "test",
+		}
+		return &v
+	},
+	expectURLString: "http://localhost:8081/u/test",
+}, {
+	about:     "* placeholder allowed only at the ned",
+	urlString: "http://localhost:8081/u/*name/document",
+	val: func() interface{} {
+		v := struct {
+			F1 string `httprequest:"name,path"`
+		}{
+			F1: "test",
+		}
+		return &v
+	},
+	expectError: `placeholders starting with \* are only allowed at the end`,
 },
 }
 

--- a/type.go
+++ b/type.go
@@ -47,6 +47,8 @@ type resultMaker func(reflect.Value) reflect.Value
 type unmarshaler func(v reflect.Value, p Params, makeResult resultMaker) error
 
 // marshaler marshals the specified value into params.
+// The value is always the value type, even if the field type
+// is a pointer.
 type marshaler func(reflect.Value, *Params) error
 
 // requestType holds information derived from a request
@@ -82,7 +84,6 @@ type field struct {
 var (
 	ErrUnmarshal        = errgo.New("httprequest unmarshal error")
 	ErrBadUnmarshalType = errgo.New("httprequest bad unmarshal type")
-	emptyValue          = reflect.Value{}
 )
 
 // Unmarshal takes values from given parameters and fills

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -53,6 +53,7 @@ var unmarshalTests = []struct {
 	},
 	params: httprequest.Params{
 		Request: &http.Request{
+			Header: http.Header{"Content-Type": {"application/json"}},
 			Form: url.Values{
 				"F1": {"99"},
 				"F2": {"-35", "not a number"},
@@ -147,7 +148,8 @@ var unmarshalTests = []struct {
 	},
 	params: httprequest.Params{
 		Request: &http.Request{
-			Body: body(`{"F": 99, "G": 100}`),
+			Header: http.Header{"Content-Type": {"application/json"}},
+			Body:   body(`{"F": 99, "G": 100}`),
 		},
 	},
 }, {
@@ -157,7 +159,8 @@ var unmarshalTests = []struct {
 	}{},
 	params: httprequest.Params{
 		Request: &http.Request{
-			Body: body(`{"F": 99, "G": 100}`),
+			Header: http.Header{"Content-Type": {"application/json"}},
+			Body:   body(`{"F": 99, "G": 100}`),
 		},
 	},
 }, {
@@ -296,7 +299,8 @@ var unmarshalTests = []struct {
 	}{},
 	params: httprequest.Params{
 		Request: &http.Request{
-			Body: body("invalid JSON"),
+			Header: http.Header{"Content-Type": {"application/json"}},
+			Body:   body("invalid JSON"),
 		},
 	},
 	expectError: "cannot unmarshal into field: cannot unmarshal request body: invalid character 'i' looking for beginning of value",
@@ -307,7 +311,8 @@ var unmarshalTests = []struct {
 	}{},
 	params: httprequest.Params{
 		Request: &http.Request{
-			Body: errorReader("some error"),
+			Header: http.Header{"Content-Type": {"application/json"}},
+			Body:   errorReader("some error"),
 		},
 	},
 	expectError: "cannot unmarshal into field: cannot read request body: some error",
@@ -333,7 +338,8 @@ var unmarshalTests = []struct {
 	},
 	params: httprequest.Params{
 		Request: &http.Request{
-			Body: body(`"hello"`),
+			Header: http.Header{"Content-Type": {"application/json"}},
+			Body:   body(`"hello"`),
 		},
 	},
 }, {
@@ -346,6 +352,18 @@ var unmarshalTests = []struct {
 	about:       "non-struct pointer",
 	val:         0,
 	expectError: `bad type \*int: type is not pointer to struct`,
+}, {
+	about: "unmarshaling with wrong request content type",
+	val: struct {
+		A string `httprequest:",body"`
+	}{},
+	params: httprequest.Params{
+		Request: &http.Request{
+			Header: http.Header{"Content-Type": {"text/html"}},
+			Body:   body("invalid JSON"),
+		},
+	},
+	expectError: "cannot unmarshal into field: unexpected content type: expected \"application/json\", got \"text/html\"",
 }}
 
 type SFG struct {


### PR DESCRIPTION
Added implementation of the Marshal method that takes the base url, method and
and input (pointer to struct) and returns an http Request with appropriately
marshaled input.
