### PR TITLE
implement ErrorMapper.Handlers

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -146,7 +146,7 @@ func BenchmarkHandle2Fields(b *testing.B) {
 			panic("unreachable")
 		}
 		return results, nil
-	}))
+	}).Handle)
 }
 
 func BenchmarkHandle2FieldsUnmarshalOnly(b *testing.B) {
@@ -279,7 +279,7 @@ func BenchmarkHandle4Fields(b *testing.B) {
 			panic("unreachable")
 		}
 		return results, nil
-	}))
+	}).Handle)
 }
 
 func BenchmarkHandle4FieldsUnmarshalOnly(b *testing.B) {
@@ -330,7 +330,7 @@ func benchmarkHandle4Fields(b *testing.B, handle func(w http.ResponseWriter, req
 func BenchmarkHandle2StringFields(b *testing.B) {
 	benchmarkHandleNFields(b, 2, errorMapper.Handle(func(p httprequest.Params, arg *testParams2StringFields) error {
 		return nil
-	}))
+	}).Handle)
 }
 
 func BenchmarkHandle2StringFieldsUnmarshalOnly(b *testing.B) {
@@ -352,7 +352,7 @@ func BenchmarkHandle2StringFieldsTrad(b *testing.B) {
 func BenchmarkHandle4StringFields(b *testing.B) {
 	benchmarkHandleNFields(b, 4, errorMapper.Handle(func(p httprequest.Params, arg *testParams4StringFields) error {
 		return nil
-	}))
+	}).Handle)
 }
 
 func BenchmarkHandle4StringFieldsUnmarshalOnly(b *testing.B) {
@@ -376,7 +376,7 @@ func BenchmarkHandle4StringFieldsTrad(b *testing.B) {
 func BenchmarkHandle8StringFields(b *testing.B) {
 	benchmarkHandleNFields(b, 8, errorMapper.Handle(func(p httprequest.Params, arg *testParams8StringFields) error {
 		return nil
-	}))
+	}).Handle)
 }
 
 func BenchmarkHandle8StringFieldsUnmarshalOnly(b *testing.B) {
@@ -404,7 +404,7 @@ func BenchmarkHandle8StringFieldsTrad(b *testing.B) {
 func BenchmarkHandle16StringFields(b *testing.B) {
 	benchmarkHandleNFields(b, 16, errorMapper.Handle(func(p httprequest.Params, arg *testParams16StringFields) error {
 		return nil
-	}))
+	}).Handle)
 }
 
 func BenchmarkHandle16StringFieldsUnmarshalOnly(b *testing.B) {

--- a/example_handlers_test.go
+++ b/example_handlers_test.go
@@ -1,0 +1,65 @@
+package httprequest_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+
+	"github.com/julienschmidt/httprouter"
+
+	"github.com/juju/httprequest"
+)
+
+type arithHandler struct {
+}
+
+type number struct {
+	N int
+}
+
+func (arithHandler) Add(arg *struct {
+	httprequest.Route `httprequest:"GET /:A/add/:B"`
+	A                 int `httprequest:",path"`
+	B                 int `httprequest:",path"`
+}) (number, error) {
+	return number{
+		N: arg.A + arg.B,
+	}, nil
+}
+
+func ExampleErrorMapper_Handlers() {
+	f := func(p httprequest.Params) (arithHandler, error) {
+		fmt.Printf("handle %s %s\n", p.Request.Method, p.Request.URL)
+		return arithHandler{}, nil
+	}
+	router := httprouter.New()
+	for _, h := range exampleErrorMapper.Handlers(f) {
+		router.Handle(h.Method, h.Path, h.Handle)
+	}
+	srv := httptest.NewServer(router)
+	resp, err := http.Get(srv.URL + "/123/add/11")
+	if err != nil {
+		panic(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		panic("status " + resp.Status)
+	}
+	fmt.Println("result:")
+	io.Copy(os.Stdout, resp.Body)
+	// Output: handle GET /123/add/11
+	// result:
+	// {"N":134}
+}
+
+type exampleErrorResponse struct {
+	Message string
+}
+
+var exampleErrorMapper httprequest.ErrorMapper = func(err error) (int, interface{}) {
+	return http.StatusInternalServerError, &exampleErrorResponse{
+		Message: err.Error(),
+	}
+}


### PR DESCRIPTION
This makes it possible to define a bunch of handlers on the
same type, each implementing a separate API endpoint.
