### PR TITLE
client: always use DoWithBody when implemented

### DIFF
--- a/client.go
+++ b/client.go
@@ -96,7 +96,8 @@ func (c *Client) Call(params, resp interface{}) error {
 	}
 	var httpResp *http.Response
 	body := req.Body.(BytesReaderCloser)
-	if doer1, ok := doer.(DoerWithBody); ok && body.Len() > 0 {
+	// Always use DoWithBody when available.
+	if doer1, ok := doer.(DoerWithBody); ok {
 		req.Body = nil
 		httpResp, err = doer1.DoWithBody(req, body)
 	} else {

--- a/client_test.go
+++ b/client_test.go
@@ -89,11 +89,11 @@ var callTests = []struct {
 	},
 	expectResp: &chM2Resp{"hello", 999},
 }, {
-	about: "doer with body but no body",
+	about: "doer that implements DoWithBody but no body",
 	client: httprequest.Client{
 		Doer: doerFunc(func(req *http.Request, body io.ReadSeeker) (*http.Response, error) {
-			if body != nil {
-				panic("DoWithBody called unexpectedly")
+			if body == nil {
+				panic("Do called but DoWithBody should always be called")
 			}
 			return http.DefaultClient.Do(req)
 		}),


### PR DESCRIPTION
This means we don't ever pass a request with a non-empty
body to bakery.Client.Do, which causes it to fail.
