### PR TITLE
implement Client.Do and Client.Get

### DIFF
--- a/checkisjson_test.go
+++ b/checkisjson_test.go
@@ -49,7 +49,7 @@ var checkIsJSONTests = []struct {
 }, {
 	about:       "large text body",
 	contentType: "text/plain",
-	body:        strings.Repeat("x", 1024 + 300),
+	body:        strings.Repeat("x", 1024+300),
 	expectError: `unexpected content type text/plain; want application/json; content: ` + strings.Repeat("x", 1024) + ` \.\.\. \[300 bytes omitted]`,
 }, {
 	about:       "html with no text",

--- a/client_test.go
+++ b/client_test.go
@@ -1,18 +1,20 @@
 package httprequest_test
 
 import (
+	"bytes"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 
 	jc "github.com/juju/testing/checkers"
+	"github.com/julienschmidt/httprouter"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
 
 	"github.com/juju/httprequest"
-	"github.com/julienschmidt/httprouter"
 )
 
 type clientSuite struct{}
@@ -54,7 +56,7 @@ var callTests = []struct {
 		P:    "hello",
 		Body: struct{ I bool }{true},
 	},
-	expectError: `httprequest: cannot unmarshal parameters: cannot unmarshal into field: cannot unmarshal request body: json: cannot unmarshal bool into Go value of type int`,
+	expectError: `POST http://.*/m2/hello: httprequest: cannot unmarshal parameters: cannot unmarshal into field: cannot unmarshal request body: json: cannot unmarshal bool into Go value of type int`,
 	expectCause: &httprequest.RemoteError{
 		Message: `cannot unmarshal parameters: cannot unmarshal into field: cannot unmarshal request body: json: cannot unmarshal bool into Go value of type int`,
 		Code:    "bad request",
@@ -67,11 +69,11 @@ var callTests = []struct {
 		},
 	},
 	req:         &chM3Req{},
-	expectError: `unexpected HTTP response status: 500 Internal Server Error`,
+	expectError: `GET http://.*/m3: unexpected HTTP response status: 500 Internal Server Error`,
 }, {
 	about:       "unexpected redirect",
 	req:         &chM2RedirectM2Req{},
-	expectError: `unexpected redirect \(status 307 Temporary Redirect\) from "http://.*/m2/foo//" to "http://.*/m2/foo"`,
+	expectError: `POST http://.*/m2/foo//: unexpected redirect \(status 307 Temporary Redirect\) from "http://.*/m2/foo//" to "http://.*/m2/foo"`,
 }, {
 	about: "doer with body",
 	client: httprequest.Client{
@@ -104,17 +106,8 @@ var callTests = []struct {
 	expectResp: &chM1Resp{"hello"},
 }}
 
-func (*clientSuite) TestCall(c *gc.C) {
-	f := func(p httprequest.Params) (clientHandlers, error) {
-		return clientHandlers{}, nil
-	}
-	handlers := errorMapper.Handlers(f)
-	router := httprouter.New()
-	for _, h := range handlers {
-		router.Handle(h.Method, h.Path, h.Handle)
-	}
-
-	srv := httptest.NewServer(router)
+func (s *clientSuite) TestCall(c *gc.C) {
+	srv := s.newServer()
 	defer srv.Close()
 
 	for i, test := range callTests {
@@ -138,10 +131,163 @@ func (*clientSuite) TestCall(c *gc.C) {
 	}
 }
 
+func mustNewRequest(url string, method string, body io.Reader) *http.Request {
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		panic(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+var doTests = []struct {
+	about   string
+	client  httprequest.Client
+	request *http.Request
+	body    io.ReadSeeker
+
+	expectError string
+	expectCause interface{}
+	expectResp  interface{}
+}{{
+	about:      "GET success",
+	request:    mustNewRequest("/m1/hello", "GET", nil),
+	expectResp: &chM1Resp{"hello"},
+}, {
+	about:   "appendURL error",
+	request: mustNewRequest("/m1/hello", "GET", nil),
+	client: httprequest.Client{
+		BaseURL: ":::",
+	},
+	expectError: `cannot parse ":::": parse :::: missing protocol scheme`,
+}, {
+	about:       "body supplied in request",
+	request:     mustNewRequest("/m1/hello", "GET", strings.NewReader("")),
+	expectError: `GET http://.*/m1/hello: request body supplied unexpectedly`,
+}, {
+	about:      "content length is inferred from strings.Reader",
+	request:    mustNewRequest("/content-length", "PUT", nil),
+	body:       strings.NewReader("hello"),
+	expectResp: newInt64(int64(len("hello"))),
+}, {
+	about:      "content length is inferred from bytes.Reader",
+	request:    mustNewRequest("/content-length", "PUT", nil),
+	body:       bytes.NewReader([]byte("hello")),
+	expectResp: newInt64(int64(len("hello"))),
+}, {
+	about: "DoWithBody implemented but no body",
+	client: httprequest.Client{
+		Doer: doerFunc(func(req *http.Request, body io.ReadSeeker) (*http.Response, error) {
+			if body != nil {
+				panic("DoWithBody called when Do expected")
+			}
+			return http.DefaultClient.Do(req)
+		}),
+	},
+	request:    mustNewRequest("/m1/hello", "GET", nil),
+	expectResp: &chM1Resp{"hello"},
+}, {
+	about: "DoWithBody not implemented and body present",
+	client: httprequest.Client{
+		Doer: doerOnlyFunc(func(req *http.Request) (*http.Response, error) {
+			return http.DefaultClient.Do(req)
+		}),
+	},
+	request: mustNewRequest("/m2/foo", "POST", nil),
+	body:    strings.NewReader(`{"I": 999}`),
+	expectResp: &chM2Resp{
+		P:   "foo",
+		Arg: 999,
+	},
+}, {
+	about: "DoWithBody implemented and body present",
+	client: httprequest.Client{
+		Doer: doerFunc(func(req *http.Request, body io.ReadSeeker) (*http.Response, error) {
+			if body == nil {
+				panic("Do called when DoWithBody expected")
+			}
+			req.Body = ioutil.NopCloser(body)
+			return http.DefaultClient.Do(req)
+		}),
+	},
+	request: mustNewRequest("/m2/foo", "POST", nil),
+	body:    strings.NewReader(`{"I": 999}`),
+	expectResp: &chM2Resp{
+		P:   "foo",
+		Arg: 999,
+	},
+}, {
+	about: "Do returns error",
+	client: httprequest.Client{
+		Doer: doerOnlyFunc(func(req *http.Request) (*http.Response, error) {
+			return nil, errgo.Newf("an error")
+		}),
+	},
+	request:     mustNewRequest("/m2/foo", "POST", nil),
+	body:        strings.NewReader(`{"I": 999}`),
+	expectError: "POST http://.*/m2/foo: an error",
+}}
+
+func newInt64(i int64) *int64 {
+	return &i
+}
+
+func (s *clientSuite) TestDo(c *gc.C) {
+	srv := s.newServer()
+	defer srv.Close()
+	for i, test := range doTests {
+		c.Logf("test %d: %s", i, test.about)
+		var resp interface{}
+		if test.expectResp != nil {
+			resp = reflect.New(reflect.TypeOf(test.expectResp).Elem()).Interface()
+		}
+		client := test.client
+		if client.BaseURL == "" {
+			client.BaseURL = srv.URL
+		}
+		err := client.Do(test.request, test.body, resp)
+		if test.expectError != "" {
+			c.Assert(err, gc.ErrorMatches, test.expectError)
+			if test.expectCause != nil {
+				c.Assert(errgo.Cause(err), jc.DeepEquals, test.expectCause)
+			}
+			continue
+		}
+		c.Assert(err, gc.IsNil)
+		c.Assert(resp, jc.DeepEquals, test.expectResp)
+	}
+}
+
+func (s *clientSuite) TestGet(c *gc.C) {
+	srv := s.newServer()
+	defer srv.Close()
+	client := httprequest.Client{
+		BaseURL: srv.URL,
+	}
+	var resp chM1Resp
+	err := client.Get("/m1/foo", &resp)
+	c.Assert(err, gc.IsNil)
+	c.Assert(resp, jc.DeepEquals, chM1Resp{"foo"})
+}
+
+func (*clientSuite) newServer() *httptest.Server {
+	f := func(p httprequest.Params) (clientHandlers, error) {
+		return clientHandlers{}, nil
+	}
+	handlers := errorMapper.Handlers(f)
+	router := httprouter.New()
+	for _, h := range handlers {
+		router.Handle(h.Method, h.Path, h.Handle)
+	}
+
+	return httptest.NewServer(router)
+}
+
 var appendURLTests = []struct {
-	u      string
-	p      string
-	expect string
+	u           string
+	p           string
+	expect      string
+	expectError string
 }{{
 	u:      "http://foo",
 	p:      "bar",
@@ -166,17 +312,43 @@ var appendURLTests = []struct {
 	u:      "http://xxx",
 	p:      "",
 	expect: "http://xxx",
+}, {
+	u:           "http://xxx.com",
+	p:           "http://foo.com",
+	expectError: "relative URL specifies a host",
+}, {
+	u:      "http://xxx.com/a/b",
+	p:      "foo?a=45&b=c",
+	expect: "http://xxx.com/a/b/foo?a=45&b=c",
+}, {
+	u:      "http://xxx.com",
+	p:      "?a=45&b=c",
+	expect: "http://xxx.com?a=45&b=c",
+}, {
+	u:      "http://xxx.com/a?z=w",
+	p:      "foo?a=45&b=c",
+	expect: "http://xxx.com/a/foo?z=w&a=45&b=c",
+}, {
+	u:      "http://xxx.com?z=w",
+	p:      "/a/b/c",
+	expect: "http://xxx.com/a/b/c?z=w",
 }}
 
 func (*clientSuite) TestAppendURL(c *gc.C) {
 	for i, test := range appendURLTests {
 		c.Logf("test %d: %s %s", i, test.u, test.p)
-		c.Assert(httprequest.AppendURL(test.u, test.p), gc.Equals, test.expect)
+		u, err := httprequest.AppendURL(test.u, test.p)
+		if test.expectError != "" {
+			c.Assert(u, gc.IsNil)
+			c.Assert(err, gc.ErrorMatches, test.expectError)
+		} else {
+			c.Assert(err, gc.IsNil)
+			c.Assert(u.String(), gc.Equals, test.expect)
+		}
 	}
 }
 
-type clientHandlers struct {
-}
+type clientHandlers struct{}
 
 type chM1Req struct {
 	httprequest.Route `httprequest:"GET /m1/:P"`
@@ -228,6 +400,14 @@ func (clientHandlers) M3(p *chM3Req) error {
 	return errgo.New("m3 error")
 }
 
+type chContentLengthReq struct {
+	httprequest.Route `httprequest:"PUT /content-length"`
+}
+
+func (clientHandlers) ContentLength(rp httprequest.Params, p *chContentLengthReq) (int64, error) {
+	return rp.Request.ContentLength, nil
+}
+
 type doerFunc func(req *http.Request, body io.ReadSeeker) (*http.Response, error)
 
 func (f doerFunc) Do(req *http.Request) (*http.Response, error) {
@@ -242,4 +422,10 @@ func (f doerFunc) DoWithBody(req *http.Request, body io.ReadSeeker) (*http.Respo
 		panic("unexpected nil body argument")
 	}
 	return f(req, body)
+}
+
+type doerOnlyFunc func(req *http.Request) (*http.Response, error)
+
+func (f doerOnlyFunc) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
 }


### PR DESCRIPTION
These make it easier to make HTTP request that return JSON
without defining a request type.

We also change appendURL so that it can work OK with
query parameters.
