### PR TITLE
Support custom headers.

### DIFF
--- a/client.go
+++ b/client.go
@@ -67,6 +67,9 @@ var DefaultErrorUnmarshaler = ErrorUnmarshaler(new(RemoteError))
 // unmarshals the response into the given response parameter,
 // which should be a pointer to the response value.
 //
+// If params implements the HeaderSetter interface, its SetHeader method
+// will be called to add additional headers to the HTTP request.
+//
 // If resp is nil, the response will be ignored if the
 // request was successful.
 //

--- a/type.go
+++ b/type.go
@@ -235,6 +235,7 @@ const (
 	sourcePath
 	sourceForm
 	sourceBody
+	sourceHeader
 )
 
 type tag struct {
@@ -264,6 +265,8 @@ func parseTag(rtag reflect.StructTag, fieldName string) (tag, error) {
 			t.source = sourceForm
 		case "body":
 			t.source = sourceBody
+		case "header":
+			t.source = sourceHeader
 		default:
 			return tag{}, fmt.Errorf("unknown tag flag %q", f)
 		}

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -360,6 +360,45 @@ var unmarshalTests = []struct {
 		},
 	},
 	expectError: `cannot unmarshal into field: unexpected content type text/html; want application/json; content: invalid JSON`,
+}, {
+	about: "struct with header fields",
+	val: struct {
+		F1 int    `httprequest:"x1,header"`
+		G1 string `httprequest:"g1,header"`
+	}{
+		F1: 99,
+		G1: "g1 val",
+	},
+	params: httprequest.Params{
+		Request: &http.Request{
+			Header: http.Header{
+				"x1": {"99"},
+				"g1": {"g1 val"},
+			},
+		},
+	},
+}, {
+	about: "all field header values",
+	val: struct {
+		A []string  `httprequest:",header"`
+		B *[]string `httprequest:",header"`
+		C []string  `httprequest:",header"`
+		D *[]string `httprequest:",header"`
+	}{
+		A: []string{"a1", "a2"},
+		B: func() *[]string {
+			x := []string{"b1", "b2", "b3"}
+			return &x
+		}(),
+	},
+	params: httprequest.Params{
+		Request: &http.Request{
+			Header: http.Header{
+				"A": {"a1", "a2"},
+				"B": {"b1", "b2", "b3"},
+			},
+		},
+	},
 }}
 
 type SFG struct {


### PR DESCRIPTION
Custom header are supported through two mechanisms. a new header tag,
and support for HeaderSetters in the marshaler.
