### PR TITLE
allow bodies in GET requests

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -216,9 +216,6 @@ func marshalNop(v reflect.Value, p *Params) error {
 // mashalBody marshals the specified value into the body of the http request.
 func marshalBody(v reflect.Value, p *Params) error {
 	// TODO allow body types that aren't necessarily JSON.
-	if p.Request.Method == "GET" || p.Request.Method == "HEAD" {
-		return errgo.Newf("cannot specify a body with %s method", p.Request.Method)
-	}
 	data, err := json.Marshal(v.Addr().Interface())
 	if err != nil {
 		return errgo.Notef(err, "cannot marshal request body")

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -216,16 +216,19 @@ var marshalTests = []struct {
 	about:     "marshal to body of a GET request",
 	urlString: "http://localhost:8081/u",
 	val: &struct {
-		F1 string `httprequest:"user,body"`
+		F1 string `httprequest:",body"`
 	}{
 		F1: "hello test",
 	},
-	expectError: "cannot marshal field: cannot specify a body with GET method",
+	// Providing a body to a GET request is unusual but
+	// some people do it anyway.
+
+	expectBody: newString(`"hello test"`),
 }, {
 	about:     "marshal to nil value to body",
 	urlString: "http://localhost:8081/u",
 	val: &struct {
-		F1 *string `httprequest:"user,body"`
+		F1 *string `httprequest:",body"`
 	}{
 		F1: nil,
 	},


### PR DESCRIPTION
Some APIs (e.g. juju's) require bodies in GET requests. Woo.
