### PR TITLE
add PathPattern to Params

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -80,9 +80,10 @@ func (e ErrorMapper) Handle(f interface{}) Handler {
 		Path:   rt.path,
 		Handle: func(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
 			hf(fv, Params{
-				Response: w,
-				Request:  req,
-				PathVar:  p,
+				Response:    w,
+				Request:     req,
+				PathVar:     p,
+				PathPattern: rt.path,
 			})
 		},
 	}
@@ -140,9 +141,10 @@ func (e ErrorMapper) Handlers(f interface{}) []Handler {
 		handler := func(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
 			terrv := fv.Call([]reflect.Value{
 				reflect.ValueOf(Params{
-					Response: w,
-					Request:  req,
-					PathVar:  p,
+					Response:    w,
+					Request:     req,
+					PathVar:     p,
+					PathPattern: rt.path,
 				}),
 			})
 			tv, errv := terrv[0], terrv[1]
@@ -154,9 +156,10 @@ func (e ErrorMapper) Handlers(f interface{}) []Handler {
 				defer tv.Interface().(io.Closer).Close()
 			}
 			hf(tv.Method(i), Params{
-				Response: w,
-				Request:  req,
-				PathVar:  p,
+				Response:    w,
+				Request:     req,
+				PathVar:     p,
+				PathPattern: rt.path,
 			})
 
 		}
@@ -365,6 +368,9 @@ type ErrorHandler func(Params) error
 // HandleJSON returns a handler that writes the return value of handle
 // as a JSON response. If handle returns an error, it is passed through
 // the error mapper.
+//
+// Note that the Params argument passed to handle will not
+// have its PathPattern set as that information is not available.
 func (e ErrorMapper) HandleJSON(handle JSONHandler) httprouter.Handle {
 	return func(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
 		val, err := handle(Params{
@@ -383,6 +389,9 @@ func (e ErrorMapper) HandleJSON(handle JSONHandler) httprouter.Handle {
 
 // HandleErrors returns a handler that passes any non-nil error returned
 // by handle through the error mapper and writes it as a JSON response.
+//
+// Note that the Params argument passed to handle will not
+// have its PathPattern set as that information is not available.
 func (e ErrorMapper) HandleErrors(handle ErrorHandler) httprouter.Handle {
 	return func(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
 		w1 := responseWriter{

--- a/type.go
+++ b/type.go
@@ -38,6 +38,11 @@ type Params struct {
 	Response http.ResponseWriter
 	Request  *http.Request
 	PathVar  httprouter.Params
+	// PathPattern holds the path pattern matched by httprouter.
+	// It is only set where httprequest has the information;
+	// that is where the call was made by ErrorMapper.Handler
+	// or ErrorMapper.Handlers.
+	PathPattern string
 }
 
 // resultMaker is provided to the unmarshal functions.

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -133,22 +133,6 @@ var unmarshalTests = []struct {
 		},
 	},
 }, {
-	about: "unexported embedded type for body works ok",
-	val: struct {
-		sFG `httprequest:",body"`
-	}{
-		sFG: sFG{
-			F: 99,
-			G: 100,
-		},
-	},
-	params: httprequest.Params{
-		Request: &http.Request{
-			Header: http.Header{"Content-Type": {"application/json"}},
-			Body:   body(`{"F": 99, "G": 100}`),
-		},
-	},
-}, {
 	about: "unexported type for body is ignored",
 	val: struct {
 		foo sFG `httprequest:",body"`


### PR DESCRIPTION
This makes it straightforward for handlers (and the
handler value function) to know what pattern
they've been invoked with.

We also remove a test that doesn't work under Go 1.6
because anonymous fields are more restrictive.
