### PR TITLE
Add context support to the client.

### DIFF
--- a/cmd/httprequest-generate-client/main.go
+++ b/cmd/httprequest-generate-client/main.go
@@ -67,15 +67,15 @@ type {{.ClientType}} struct {
 {{range .Methods}}
 {{if .RespType}}
 	{{.Doc}}
-	func (c *{{$.ClientType}}) {{.Name}}(p *{{.ParamType}}) ({{.RespType}}, error) {
+	func (c *{{$.ClientType}}) {{.Name}}(ctx context.Context, p *{{.ParamType}}) ({{.RespType}}, error) {
 		var r {{.RespType}}
-		err := c.Client.Call(p, &r)
+		err := c.Client.Call(ctx, p, &r)
 		return r, err
 	}
 {{else}}
 	{{.Doc}}
-	func (c *{{$.ClientType}}) {{.Name}}(p *{{.ParamType}}) (error) {
-		return c.Client.Call(p, nil)
+	func (c *{{$.ClientType}}) {{.Name}}(ctx context.Context, p *{{.ParamType}}) (error) {
+		return c.Client.Call(ctx, p, nil)
 	}
 {{end}}
 {{end}}
@@ -166,6 +166,7 @@ func serverMethods(serverPkg, serverType, localPkg string) ([]method, []string, 
 
 	imports := map[string]string{
 		"github.com/juju/httprequest": "httprequest",
+		"golang.org/x/net/context":    "context",
 		localPkg:                      "",
 	}
 	var methods []method

--- a/context.go
+++ b/context.go
@@ -13,30 +13,33 @@ import (
 
 // RequestUUIDHeader contains the name of the header used to store the
 // request UUID.
-const RequestUUIDHeader = "Request-UUID"
+const RequestUUIDHeader = "Request-Uuid"
 
 var uuidGen = fastuuid.MustNewGenerator()
 
 type requestUUIDContextKey struct{}
 
-// RequestUUID returns the unique identifier of the request. This will
-// have either been taken from a Request-UUID header or assigned when
-// the request is initially processed by httprequest. If the given
-// context doesn't contain a request UUID then the return value will be
-// the empty string.
-func RequestUUID(ctx context.Context) string {
+// RequestUUIDFromContext returns the unique identifier of the request.
+// This will have either been taken from a Request-UUID header or
+// assigned when the request is initially processed by httprequest. If
+// the given context doesn't contain a request UUID then the return value
+// will be the empty string.
+func RequestUUIDFromContext(ctx context.Context) string {
 	v, _ := ctx.Value(requestUUIDContextKey{}).(string)
 	return v
 }
 
-// contextWithRequestUUID adds a request UUID to the given context. The request
-// UUID either comes from a Request-UUID header in the given Request,
-// or generates a random UUID.
-func contextWithRequestUUID(ctx context.Context, req *http.Request) context.Context {
-	uuid := req.Header.Get(RequestUUIDHeader)
-	if uuid == "" {
-		bytes := uuidGen.Next()
-		uuid = fmt.Sprintf("%x", bytes)
-	}
+// ContextWithRequestUUID adds the given request UUID to the given context.
+func ContextWithRequestUUID(ctx context.Context, uuid string) context.Context {
 	return context.WithValue(ctx, requestUUIDContextKey{}, uuid)
+}
+
+// uuidFromRequest gets a UUID for the request. If a Request-UUID header
+// is present then the UUID will be taken from that otherwise a new
+// random UUID will be generated.
+func uuidFromRequest(req *http.Request) string {
+	if uuid := req.Header.Get(RequestUUIDHeader); uuid != "" {
+		return uuid
+	}
+	return fmt.Sprintf("%x", uuidGen.Next())
 }

--- a/context_go17.go
+++ b/context_go17.go
@@ -12,10 +12,14 @@ import (
 
 func contextFromRequest(req *http.Request) (context.Context, *http.Request, context.CancelFunc) {
 	ctx := req.Context()
-	ctx = contextWithRequestUUID(ctx, req)
+	ctx = ContextWithRequestUUID(ctx, uuidFromRequest(req))
 	req = req.WithContext(ctx)
 	// Note there is no need to make httprequest cancel the context
 	// as the standard HTTP server will cancel it when the ServeHTTP
 	// method completes.
 	return ctx, req, func() {}
+}
+
+func requestWithContext(req *http.Request, ctx context.Context) *http.Request {
+	return req.WithContext(ctx)
 }

--- a/context_prego17.go
+++ b/context_prego17.go
@@ -13,6 +13,10 @@ import (
 
 func contextFromRequest(req *http.Request) (context.Context, *http.Request, context.CancelFunc) {
 	ctx, cancel := context.WithCancel(context.Background())
-	ctx = contextWithRequestUUID(ctx, req)
+	ctx = ContextWithRequestUUID(ctx, uuidFromRequest(req))
 	return ctx, req, cancel
+}
+
+func requestWithContext(req *http.Request, _ context.Context) *http.Request {
+	return req
 }

--- a/context_test.go
+++ b/context_test.go
@@ -19,7 +19,7 @@ type contextSuite struct{}
 var _ = gc.Suite(&contextSuite{})
 
 func (s *contextSuite) TestRequestUUIDNotInContext(c *gc.C) {
-	c.Assert(httprequest.RequestUUID(context.Background()), gc.Equals, "")
+	c.Assert(httprequest.RequestUUIDFromContext(context.Background()), gc.Equals, "")
 }
 
 type testRequest struct {
@@ -28,7 +28,7 @@ type testRequest struct {
 
 func (s *contextSuite) TestRequestUUIDFromHeader(c *gc.C) {
 	hnd := errorMapper.Handle(func(p httprequest.Params, req *testRequest) {
-		uuid := httprequest.RequestUUID(p.Context)
+		uuid := httprequest.RequestUUIDFromContext(p.Context)
 		c.Assert(uuid, gc.Equals, "test-uuid")
 	})
 	req, err := http.NewRequest("GET", "/foo", nil)
@@ -40,7 +40,7 @@ func (s *contextSuite) TestRequestUUIDFromHeader(c *gc.C) {
 
 func (s *contextSuite) TestRequestUUIDGenerated(c *gc.C) {
 	hnd := errorMapper.Handle(func(p httprequest.Params, req *testRequest) {
-		uuid := httprequest.RequestUUID(p.Context)
+		uuid := httprequest.RequestUUIDFromContext(p.Context)
 		c.Assert(uuid, gc.Not(gc.Equals), "")
 	})
 	req, err := http.NewRequest("GET", "/foo", nil)

--- a/handler_test.go
+++ b/handler_test.go
@@ -918,7 +918,7 @@ func (s *handlerSuite) TestHandleErrors(c *gc.C) {
 		c.Assert(p.PathPattern, gc.Equals, "")
 		ctx := p.Context
 		c.Assert(ctx, gc.Not(gc.IsNil))
-		uuid := httprequest.RequestUUID(ctx)
+		uuid := httprequest.RequestUUIDFromContext(ctx)
 		c.Assert(uuid, gc.Not(gc.Equals), "")
 		return errUnauth
 	})
@@ -938,7 +938,7 @@ func (s *handlerSuite) TestHandleErrors(c *gc.C) {
 		c.Assert(p.PathPattern, gc.Equals, "")
 		ctx := p.Context
 		c.Assert(ctx, gc.Not(gc.IsNil))
-		uuid := httprequest.RequestUUID(ctx)
+		uuid := httprequest.RequestUUIDFromContext(ctx)
 		c.Assert(uuid, gc.Not(gc.Equals), "")
 		p.Response.WriteHeader(http.StatusCreated)
 		p.Response.Write([]byte("something"))


### PR DESCRIPTION
Require a context to be provided with client requests. Take the
Request-Uuid from the context. Support Doers that can use the context.