### PR TITLE
use consistently annotated errors

### DIFF
--- a/handler_test.go
+++ b/handler_test.go
@@ -858,10 +858,6 @@ func (*handlerSuite) TestSetHeader(c *gc.C) {
 	c.Assert(rec.Header().Get("some-custom-header"), gc.Equals, "yes")
 }
 
-func (*handlerSuite) TestSetHeaderOnErrorMapper(c *gc.C) {
-	// TODO write this test!
-}
-
 var testServer = httprequest.Server{
 	ErrorMapper: testErrorMapper,
 }


### PR DESCRIPTION
We make returned errors match those of net/http
in appearance, and avoid adding annotation where
it would be redundant.

We also remove TestSetHeaderOnErrorMapper as the
this case is adequately tested in TestWriteError.