### PR TITLE
allow handler root function access to request value

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -322,7 +322,7 @@ func checkHandleType(t, argInterfacet reflect.Type) (*requestType, error) {
 		return nil, errgo.Notef(err, "last argument cannot be used for Unmarshal")
 	}
 	if argInterfacet != nil && !argt.Implements(argInterfacet) {
-		return nil, errgo.Notef(err, "argument does not implement interface required by root handler %v", argInterfacet)
+		return nil, errgo.Notef(err, "argument of type %v does not implement interface required by root handler %v", argt, argInterfacet)
 	}
 	if t.NumOut() > 0 {
 		//	func(p Params, arg *ArgT) error

--- a/handler.go
+++ b/handler.go
@@ -399,17 +399,17 @@ func (srv *Server) handlerCaller(
 func (srv *Server) handlerResponder(ft reflect.Type) func(p Params, outv []reflect.Value) {
 	switch ft.NumOut() {
 	case 0:
-		//	func(w http.ResponseWriter, p Params, arg *ArgT)
+		// func(...)
 		return func(Params, []reflect.Value) {}
 	case 1:
-		//	func(w http.ResponseWriter, p Params, arg *ArgT) error
+		// func(...) error
 		return func(p Params, outv []reflect.Value) {
 			if err := outv[0].Interface(); err != nil {
 				srv.WriteError(p.Context, p.Response, err.(error))
 			}
 		}
 	case 2:
-		//	func(header http.Header, p Params, arg *ArgT) (ResultT, error)
+		// func(...) (ResultT, error)
 		return func(p Params, outv []reflect.Value) {
 			if err := outv[1].Interface(); err != nil {
 				srv.WriteError(p.Context, p.Response, err.(error))


### PR DESCRIPTION
This will allow the top level handlers function to perform
generic checks that are also sensitive to the handler
being invoked (for example a fail-safe authorization
check).