### PR TITLE
fix handling of anonymous fields

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -61,12 +61,12 @@ var callTests = []struct {
 		P:    "hello",
 		Body: struct{ I bool }{true},
 	},
-	expectError: `Post http:.*: cannot unmarshal parameters: cannot unmarshal into field: cannot unmarshal request body: json: cannot unmarshal .*`,
+	expectError: `Post http:.*: cannot unmarshal parameters: cannot unmarshal into field Body: cannot unmarshal request body: json: cannot unmarshal .*`,
 	assertError: func(c *gc.C, err error) {
 		c.Assert(errgo.Cause(err), gc.FitsTypeOf, (*httprequest.RemoteError)(nil))
 		err1 := errgo.Cause(err).(*httprequest.RemoteError)
 		c.Assert(err1.Code, gc.Equals, "bad request")
-		c.Assert(err1.Message, gc.Matches, `cannot unmarshal parameters: cannot unmarshal into field: cannot unmarshal request body: json: cannot unmarshal .*`)
+		c.Assert(err1.Message, gc.Matches, `cannot unmarshal parameters: cannot unmarshal into field Body: cannot unmarshal request body: json: cannot unmarshal .*`)
 	},
 }, {
 	about: "error unmarshaler returns nil",

--- a/handler_test.go
+++ b/handler_test.go
@@ -293,7 +293,7 @@ var handleTests = []struct {
 		Value: "not a number",
 	}},
 	expectBody: httprequest.RemoteError{
-		Message: `cannot unmarshal parameters: cannot unmarshal into field: cannot parse "not a number" into int: expected integer`,
+		Message: `cannot unmarshal parameters: cannot unmarshal into field A: cannot parse "not a number" into int: expected integer`,
 		Code:    "bad request",
 	},
 	expectStatus: http.StatusBadRequest,
@@ -314,7 +314,7 @@ var handleTests = []struct {
 		Value: "not a number",
 	}},
 	expectBody: httprequest.RemoteError{
-		Message: `cannot unmarshal parameters: cannot unmarshal into field: cannot parse "not a number" into int: expected integer`,
+		Message: `cannot unmarshal parameters: cannot unmarshal into field A: cannot parse "not a number" into int: expected integer`,
 		Code:    "bad request",
 	},
 	expectStatus: http.StatusBadRequest,
@@ -335,7 +335,7 @@ var handleTests = []struct {
 		Value: "not a number",
 	}},
 	expectBody: httprequest.RemoteError{
-		Message: `cannot unmarshal parameters: cannot unmarshal into field: cannot parse "not a number" into int: expected integer`,
+		Message: `cannot unmarshal parameters: cannot unmarshal into field A: cannot parse "not a number" into int: expected integer`,
 		Code:    "bad request",
 	},
 	expectStatus: http.StatusBadRequest,

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -71,10 +71,8 @@ func unmarshal(p Params, xv reflect.Value, pt *requestType) error {
 	xv = xv.Elem()
 	for _, f := range pt.fields {
 		fv := xv.FieldByIndex(f.index)
-		// TODO store the field name in the field so
-		// that we can produce a nice error message.
 		if err := f.unmarshal(fv, p, f.makeResult); err != nil {
-			return errgo.WithCausef(err, ErrUnmarshal, "cannot unmarshal into field")
+			return errgo.WithCausef(err, ErrUnmarshal, "cannot unmarshal into field %s", f.name)
 		}
 	}
 	return nil


### PR DESCRIPTION
When an anonymous body-tagged field was unmarshaled,
all its fields were considered too, and allocated if they
were pointers.

This PR fixes that so that all fields within tagged anonymous
fields are ignored for unmarshaling purposes,
which also addresses a previous TODO in the code.

As part of debugging this, we added a name field to the field
type, which made it trivial to fix another TODO to add the
field name to the unmarshal error message.