### PR TITLE
add support for omitempty

### DIFF
--- a/marshal_test.go
+++ b/marshal_test.go
@@ -38,11 +38,15 @@ var marshalTests = []struct {
 	val: &struct {
 		F1 int    `httprequest:",path"`
 		F2 string `httprequest:",form"`
+		F3 string `httprequest:",form,omitempty"`
+		F4 string `httprequest:",form,omitempty"`
 	}{
 		F1: 99,
 		F2: "some text",
+		F3: "",
+		F4: "something",
 	},
-	expectURLString: "http://localhost:8081/99?F2=some+text",
+	expectURLString: "http://localhost:8081/99?F2=some+text&F4=something",
 }, {
 	about:     "struct with renamed fields",
 	urlString: "http://localhost:8081/:name",
@@ -152,6 +156,20 @@ var marshalTests = []struct {
 		F1: []string{"user1", "user2", "user3"},
 	},
 	expectError: "bad type .*: invalid target type.*",
+}, {
+	about:     "omitempty on body",
+	urlString: "http://localhost:8081/:users",
+	val: &struct {
+		Body string `httprequest:",body,omitempty"`
+	}{},
+	expectError: `bad type \*struct { Body string "httprequest:\\",body,omitempty\\"" }: bad tag "httprequest:\\",body,omitempty\\"" in field Body: can only use omitempty with form or header fields`,
+}, {
+	about:     "omitempty on path",
+	urlString: "http://localhost:8081/:Users",
+	val: &struct {
+		Users string `httprequest:",path,omitempty"`
+	}{},
+	expectError: `bad type \*struct { Users string "httprequest:\\",path,omitempty\\"" }: bad tag "httprequest:\\",path,omitempty\\"" in field Users: can only use omitempty with form or header fields`,
 }, {
 	about:     "more than one field with body tag",
 	urlString: "http://localhost:8081/user",
@@ -320,16 +338,21 @@ var marshalTests = []struct {
 		F1 string `httprequest:",header"`
 		F2 int    `httprequest:",header"`
 		F3 bool   `httprequest:",header"`
+		F4 string `httprequest:",header,omitempty"`
+		F5 string `httprequest:",header,omitempty"`
 	}{
 		F1: "some text",
 		F2: 99,
 		F3: true,
+		F4: "",
+		F5: "something",
 	},
 	expectURLString: "http://localhost:8081/",
 	expectHeader: http.Header{
 		"F1": []string{"some text"},
 		"F2": []string{"99"},
 		"F3": []string{"true"},
+		"F5": []string{"something"},
 	},
 }, {
 	about:     "struct with header slice",

--- a/type.go
+++ b/type.go
@@ -274,8 +274,9 @@ const (
 )
 
 type tag struct {
-	name   string
-	source tagSource
+	name      string
+	source    tagSource
+	omitempty bool
 }
 
 // parseTag parses the given struct tag attached to the given
@@ -302,9 +303,14 @@ func parseTag(rtag reflect.StructTag, fieldName string) (tag, error) {
 			t.source = sourceBody
 		case "header":
 			t.source = sourceHeader
+		case "omitempty":
+			t.omitempty = true
 		default:
 			return tag{}, fmt.Errorf("unknown tag flag %q", f)
 		}
+	}
+	if t.omitempty && t.source != sourceForm && t.source != sourceHeader {
+		return tag{}, fmt.Errorf("can only use omitempty with form or header fields")
 	}
 	return t, nil
 }


### PR DESCRIPTION
This is slightly different from the omitempty as implemented
by encoding/json at al, as it operates on the result of marshaling
rather than the value itself, but that's probably the right
thing to do.